### PR TITLE
Possible Typography refactorings

### DIFF
--- a/components/base/Typography.tsx
+++ b/components/base/Typography.tsx
@@ -103,12 +103,8 @@ const StyledInlineCode = styled.code`
   }
 `;
 
-const StyledLink = styled.a`
+export const Link = styled.a`
   color: ${ORANGE_PRIMARY};
-  &:hover {
-    text-decoration: underline;
-    cursor: pointer;
-  }
 `;
 
 // List styles
@@ -120,92 +116,111 @@ const ListStyles = css`
 `;
 
 // Prop types
-type Props = {
+type TypographyProps = {
   children: any;
   isDark?: boolean;
 };
 
-export const PreHeader = ({ children, isDark }: Props) => (
+interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  isDark?: boolean;
+}
+
+interface ParagraphProps extends React.HTMLAttributes<HTMLParagraphElement> {
+  isDark?: boolean;
+}
+
+interface UListProps extends React.HTMLAttributes<HTMLUListElement> {
+  isDark?: boolean;
+}
+
+interface OListProps extends React.HTMLAttributes<HTMLOListElement> {
+  isDark?: boolean;
+}
+
+interface QuoteProps extends React.HTMLAttributes<HTMLQuoteElement> {
+  isDark?: boolean;
+}
+
+export const PreHeader = ({ children, isDark }: TypographyProps) => (
   <StyledPreHeader className={classnames({ dark: isDark })}>
     {children}
   </StyledPreHeader>
 );
 
-export const H1 = ({ children, isDark }: Props) => (
-  <StyledH1 className={classnames({ dark: isDark })}>{children}</StyledH1>
+export const H1 = ({ isDark, ...props }: HeadingProps) => (
+  <StyledH1
+    {...props}
+    className={classnames(props.className, { dark: isDark })}
+  />
 );
 
-export const H2 = ({ children, isDark }: Props) => (
-  <StyledH2 className={classnames({ dark: isDark })}>{children}</StyledH2>
+export const H2 = ({ isDark, ...props }: HeadingProps) => (
+  <StyledH2
+    {...props}
+    className={classnames(props.className, { dark: isDark })}
+  />
 );
 
-export const H3 = ({ children, isDark }: Props) => (
-  <StyledH3 className={classnames({ dark: isDark })}>{children}</StyledH3>
+export const H3 = ({ isDark, ...props }: HeadingProps) => (
+  <StyledH3
+    {...props}
+    className={classnames(props.className, { dark: isDark })}
+  />
 );
 
-export const H4 = ({ children, isDark }: Props) => (
-  <StyledH4 className={classnames({ dark: isDark })}>{children}</StyledH4>
+export const H4 = ({ isDark, ...props }: HeadingProps) => (
+  <StyledH4
+    {...props}
+    className={classnames(props.className, { dark: isDark })}
+  />
 );
 
-export const H5 = ({ children, isDark }: Props) => (
-  <StyledH5 className={classnames({ dark: isDark })}>{children}</StyledH5>
+export const H5 = ({ isDark, ...props }: HeadingProps) => (
+  <StyledH5
+    {...props}
+    className={classnames(props.className, { dark: isDark })}
+  />
 );
 
-export const SubHeader = ({ children, isDark }: Props) => (
+export const SubHeader = ({ children, isDark }: TypographyProps) => (
   <StyledSubHeader className={classnames({ dark: isDark })}>
     {children}
   </StyledSubHeader>
 );
 
-export const Paragraph = ({ children, isDark }: Props) => (
-  <StyledParagraph className={classnames({ dark: isDark })}>
-    {children}
-  </StyledParagraph>
+export const Paragraph = ({ isDark, ...props }: ParagraphProps) => (
+  <StyledParagraph
+    {...props}
+    className={classnames(props.className, { dark: isDark })}
+  />
 );
 
-export const UnorderedList = ({ children, isDark }: Props) => (
+export const UnorderedList = ({ isDark, ...props }: UListProps) => (
   <ul
-    css={css`
-      ${ListStyles}
-    `}
-    className={classnames({ dark: isDark })}
-  >
-    {children.map((item) => (
-      <li key={item.id}>{item.text}</li>
-    ))}
-  </ul>
+    {...props}
+    css={ListStyles}
+    className={classnames(props.className, { dark: isDark })}
+  />
 );
 
-export const OrderedList = ({ children, isDark }: Props) => (
+export const OrderedList = ({ isDark, ...props }: OListProps) => (
   <ol
-    css={css`
-      ${ListStyles}
-    `}
-    className={classnames({ dark: isDark })}
-  >
-    {children.map((item) => (
-      <li key={item.id}>{item.text}</li>
-    ))}
-  </ol>
+    {...props}
+    css={ListStyles}
+    className={classnames(props.className, { dark: isDark })}
+  />
 );
 
-export const BlockQuote = ({ children, isDark }: Props) => (
+export const BlockQuote = ({ isDark, ...props }: QuoteProps) => (
   <blockquote
-    css={css`
-      ${ParagraphStyles}
-    `}
-    className={classnames({ dark: isDark })}
-  >
-    {children}
-  </blockquote>
+    {...props}
+    css={ParagraphStyles}
+    className={classnames(props.className, { dark: isDark })}
+  />
 );
 
-export const InlineCode = ({ children, isDark }: Props) => (
+export const InlineCode = ({ children, isDark }: TypographyProps) => (
   <StyledInlineCode className={classnames({ dark: isDark })}>
     {children}
   </StyledInlineCode>
-);
-
-export const Link = ({ children }: Props) => (
-  <StyledLink>{children}</StyledLink>
 );

--- a/components/base/__tests__/Typography.test.tsx
+++ b/components/base/__tests__/Typography.test.tsx
@@ -1,8 +1,87 @@
 import renderer from "react-test-renderer";
-import { H1, OrderedList } from "../Typography";
+import {
+  H1,
+  OrderedList,
+  H2,
+  H3,
+  H4,
+  H5,
+  Paragraph,
+  UnorderedList,
+} from "../Typography";
 
-test("H1", () => {
-  const tree = renderer.create(<H1 isDark>H1 Heading</H1>).toJSON();
+test("headings", () => {
+  const tree = renderer
+    .create(
+      <>
+        <H1 id="my-h1" className="my-class">
+          H1 Heading
+        </H1>
+        <H2 id="my-h2" className="my-class">
+          H2 Heading
+        </H2>
+        <H3 id="my-h3" className="my-class">
+          H3 Heading
+        </H3>
+        <H4 id="my-h4" className="my-class">
+          H4 Heading
+        </H4>
+        <H5 id="my-h5" className="my-class">
+          H5 Heading
+        </H5>
+      </>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+test("headings (dark)", () => {
+  const tree = renderer
+    .create(
+      <>
+        <H1 id="my-h1" className="my-class" isDark>
+          H1 Heading
+        </H1>
+        <H2 id="my-h2" className="my-class" isDark>
+          H2 Heading
+        </H2>
+        <H3 id="my-h3" className="my-class" isDark>
+          H3 Heading
+        </H3>
+        <H4 id="my-h4" className="my-class" isDark>
+          H4 Heading
+        </H4>
+        <H5 id="my-h5" className="my-class" isDark>
+          H5 Heading
+        </H5>
+      </>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+test("Paragraph", () => {
+  const tree = renderer
+    .create(
+      <Paragraph id="my-p" className="my-class">
+        Paragraph
+      </Paragraph>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+test("Paragraph (dark)", () => {
+  const tree = renderer
+    .create(
+      <Paragraph id="my-p" className="my-class" isDark>
+        Paragraph (dark)
+      </Paragraph>
+    )
+    .toJSON();
 
   expect(tree).toMatchSnapshot();
 });
@@ -10,13 +89,53 @@ test("H1", () => {
 test("OrderedList", () => {
   const tree = renderer
     .create(
-      <OrderedList>
-        {[
-          { id: "1", text: "Ordered list text goes here" },
-          { id: "2", text: "Ordered list text goes here" },
-          { id: "3", text: "Ordered list text goes here" },
-        ]}
+      <OrderedList id="my-list" className="my-class">
+        <li>Ordered list text goes here</li>
+        <li>Ordered list text goes here</li>
+        <li>Ordered list text goes here</li>
       </OrderedList>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+test("OrderedList (dark)", () => {
+  const tree = renderer
+    .create(
+      <OrderedList id="my-list" className="my-class" isDark>
+        <li>Ordered list text goes here</li>
+        <li>Ordered list text goes here</li>
+        <li>Ordered list text goes here</li>
+      </OrderedList>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+test("UnorderedList", () => {
+  const tree = renderer
+    .create(
+      <UnorderedList id="my-list" className="my-class">
+        <li>Unordered list text goes here</li>
+        <li>Unordered list text goes here</li>
+        <li>Unordered list text goes here</li>
+      </UnorderedList>
+    )
+    .toJSON();
+
+  expect(tree).toMatchSnapshot();
+});
+
+test("UnorderedList (dark)", () => {
+  const tree = renderer
+    .create(
+      <UnorderedList id="my-list" className="my-class" isDark>
+        <li>Unordered list text goes here</li>
+        <li>Unordered list text goes here</li>
+        <li>Unordered list text goes here</li>
+      </UnorderedList>
     )
     .toJSON();
 

--- a/components/base/__tests__/__snapshots__/Typography.test.tsx.snap
+++ b/components/base/__tests__/__snapshots__/Typography.test.tsx.snap
@@ -1,16 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`H1 1`] = `
-<h1
-  className="dark css-hhrgpu-StyledH1-headingStyles-headingStyles e1i8011f1"
->
-  H1 Heading
-</h1>
-`;
-
-exports[`OrderedList 1`] = `
+exports[`OrderedList (dark) 1`] = `
 <ol
-  className=" css-1736k0p-ParagraphStyles-ParagraphStyles-ListStyles-ListStyles-OrderedList-OrderedList"
+  className="my-class dark css-1ox5242-ParagraphStyles-ParagraphStyles-ListStyles-ListStyles"
+  id="my-list"
 >
   <li>
     Ordered list text goes here
@@ -22,4 +15,143 @@ exports[`OrderedList 1`] = `
     Ordered list text goes here
   </li>
 </ol>
+`;
+
+exports[`OrderedList 1`] = `
+<ol
+  className="my-class css-1ox5242-ParagraphStyles-ParagraphStyles-ListStyles-ListStyles"
+  id="my-list"
+>
+  <li>
+    Ordered list text goes here
+  </li>
+  <li>
+    Ordered list text goes here
+  </li>
+  <li>
+    Ordered list text goes here
+  </li>
+</ol>
+`;
+
+exports[`Paragraph (dark) 1`] = `
+<p
+  className="my-class dark css-1193mgq-StyledParagraph-ParagraphStyles-ParagraphStyles e1i8011f7"
+  id="my-p"
+>
+  Paragraph (dark)
+</p>
+`;
+
+exports[`Paragraph 1`] = `
+<p
+  className="my-class css-1193mgq-StyledParagraph-ParagraphStyles-ParagraphStyles e1i8011f7"
+  id="my-p"
+>
+  Paragraph
+</p>
+`;
+
+exports[`UnorderedList (dark) 1`] = `
+<ul
+  className="my-class dark css-1ox5242-ParagraphStyles-ParagraphStyles-ListStyles-ListStyles"
+  id="my-list"
+>
+  <li>
+    Unordered list text goes here
+  </li>
+  <li>
+    Unordered list text goes here
+  </li>
+  <li>
+    Unordered list text goes here
+  </li>
+</ul>
+`;
+
+exports[`UnorderedList 1`] = `
+<ul
+  className="my-class css-1ox5242-ParagraphStyles-ParagraphStyles-ListStyles-ListStyles"
+  id="my-list"
+>
+  <li>
+    Unordered list text goes here
+  </li>
+  <li>
+    Unordered list text goes here
+  </li>
+  <li>
+    Unordered list text goes here
+  </li>
+</ul>
+`;
+
+exports[`headings (dark) 1`] = `
+Array [
+  <h1
+    className="my-class dark css-19e190r-StyledH1-headingStyles-headingStyles e1i8011f1"
+    id="my-h1"
+  >
+    H1 Heading
+  </h1>,
+  <h2
+    className="my-class dark css-1hcxbbh-StyledH2-headingStyles-headingStyles e1i8011f2"
+    id="my-h2"
+  >
+    H2 Heading
+  </h2>,
+  <h3
+    className="my-class dark css-1m268t4-StyledH3-headingStyles-headingStyles e1i8011f3"
+    id="my-h3"
+  >
+    H3 Heading
+  </h3>,
+  <h4
+    className="my-class dark css-12gfugp-StyledH4-headingStyles-headingStyles e1i8011f4"
+    id="my-h4"
+  >
+    H4 Heading
+  </h4>,
+  <h5
+    className="my-class dark css-c77exq-StyledH5-headingStyles-headingStyles e1i8011f5"
+    id="my-h5"
+  >
+    H5 Heading
+  </h5>,
+]
+`;
+
+exports[`headings 1`] = `
+Array [
+  <h1
+    className="my-class css-19e190r-StyledH1-headingStyles-headingStyles e1i8011f1"
+    id="my-h1"
+  >
+    H1 Heading
+  </h1>,
+  <h2
+    className="my-class css-1hcxbbh-StyledH2-headingStyles-headingStyles e1i8011f2"
+    id="my-h2"
+  >
+    H2 Heading
+  </h2>,
+  <h3
+    className="my-class css-1m268t4-StyledH3-headingStyles-headingStyles e1i8011f3"
+    id="my-h3"
+  >
+    H3 Heading
+  </h3>,
+  <h4
+    className="my-class css-12gfugp-StyledH4-headingStyles-headingStyles e1i8011f4"
+    id="my-h4"
+  >
+    H4 Heading
+  </h4>,
+  <h5
+    className="my-class css-c77exq-StyledH5-headingStyles-headingStyles e1i8011f5"
+    id="my-h5"
+  >
+    H5 Heading
+  </h5>,
+]
 `;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,19 @@ import Pages from "../modules/pages";
 import { AnchorsSetter, AnchorsProvider } from "../components/util/Anchors";
 import AuthPage from "../components/AuthPage";
 import fetcher from "../modules/fetcher";
+import {
+  H1,
+  H2,
+  H3,
+  H4,
+  H5,
+  Paragraph,
+  UnorderedList,
+  OrderedList,
+  Link,
+  BlockQuote,
+  InlineCode,
+} from "../components/base/Typography";
 
 const STATUS_PAGE_SUMMARY_URL =
   "https://tnynfs0nwlgr.statuspage.io/api/v2/summary.json";
@@ -81,6 +94,17 @@ const TOP_BAR_PROPS = {
 
 const MDX_COMPONENTS = {
   wrapper: AnchorsSetter,
+  h1: H1,
+  h2: H2,
+  h3: H3,
+  h4: H4,
+  h5: H5,
+  p: Paragraph,
+  ol: OrderedList,
+  ul: UnorderedList,
+  a: Link,
+  blockquote: BlockQuote,
+  code: InlineCode, // only p>code, not pre>code
 };
 
 const AppWithHooks = ({ router, Component, pageProps }: any) => {

--- a/stories/base/Typography.stories.tsx
+++ b/stories/base/Typography.stories.tsx
@@ -92,7 +92,7 @@ storiesOf("base|Typography", module)
         {paragraph}
         <InlineCode isDark>{inlineCode}</InlineCode>
         {paragraph}
-        <Link isDark>{link}</Link>
+        <Link>{link}</Link>
       </Paragraph>
       <UnorderedList isDark>{unorderedlList}</UnorderedList>
       <OrderedList isDark>{orderedlList}</OrderedList>


### PR DESCRIPTION
This looks like more than it is, but it's mainly just changing the prop types for some of these elements to extend the prop types of `h1`, `h2`, etc.

For example, I noticed that when I hooked up the headings with our MDXProvider the `id` prop wasn't being passed to the underlying `h*` tag. Similarly, this updates the children of `{Unordered,Ordered}List` to be the same type as the built-in `ul` and `ol` tags accept instead of arrays containing JSON objects.

There's still some weirdness with the `code` styling for example tho:

![image](https://user-images.githubusercontent.com/309638/79364698-537a9180-7f0f-11ea-8158-5f84fb18fd35.png)

![image](https://user-images.githubusercontent.com/309638/79364772-68efbb80-7f0f-11ea-977b-79ce03496388.png)

---

We'll need to style `<code>` differently based on whether it's `p > code` or `pre > code` for the Markdown stuff.

I'm wondering if for the markdown use case it'd be more straightforward to do something like:

```tsx
const TypographyWrapper = styled.div`
  > h1, h2, h3, h4, h5, h6 {
    /* ... */
  }

  > h1 {
    /* ... */
  }

  > p {
    /* ... */

    > code {
      /* ... */
    }
  }

  > pre {
    /* ... */

    > code {
      /* ... */
    }
  }
`
```

and just wrap the Markdown stuff with that?