### PR TITLE
Add groupCodeExamples

### DIFF
--- a/components/util/__test__/__snapshots__/groupCodeExamples.test.tsx.snap
+++ b/components/util/__test__/__snapshots__/groupCodeExamples.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`groupCodeExamples 1`] = `
+Array [
+  <MockCodeExamples>
+    <MockMDXCreateElement
+      originalType="pre"
+    >
+      <MockMDXCreateElement
+        className="language-php"
+        originalType="code"
+      >
+        code example A
+      </MockMDXCreateElement>
+      <MockMDXCreateElement
+        className="language-java"
+        originalType="code"
+      >
+        code example B
+      </MockMDXCreateElement>
+    </MockMDXCreateElement>
+  </MockCodeExamples>,
+  <MockMDXCreateElement
+    originalType="p"
+  >
+    paragraph text
+  </MockMDXCreateElement>,
+  <MockCodeExamples>
+    <MockMDXCreateElement
+      originalType="pre"
+    >
+      <MockMDXCreateElement
+        className="language-php"
+        originalType="code"
+      >
+        code example C
+      </MockMDXCreateElement>
+      <MockMDXCreateElement
+        className="language-java"
+        originalType="code"
+      >
+        code example D
+      </MockMDXCreateElement>
+    </MockMDXCreateElement>
+  </MockCodeExamples>,
+]
+`;

--- a/components/util/__test__/groupCodeExamples.test.tsx
+++ b/components/util/__test__/groupCodeExamples.test.tsx
@@ -1,0 +1,54 @@
+import { createElement } from "react";
+import groupCodeExamples from "../groupCodeExamples";
+
+function MockMDXCreateElement(props: {
+  children: any;
+  originalType: string;
+  id?: string;
+  className?: string;
+}) {
+  return createElement(props.originalType, {
+    children: props.children,
+    id: props.id,
+  });
+}
+
+function MockCodeExamples({ children: c }: any) {
+  return (
+    <>
+      <h3>code examples</h3>
+      {c}
+    </>
+  );
+}
+
+test("groupCodeExamples", () => {
+  expect(
+    groupCodeExamples({
+      children: [
+        <MockMDXCreateElement originalType="pre">
+          <MockMDXCreateElement originalType="code" className="language-php">
+            code example A
+          </MockMDXCreateElement>
+          <MockMDXCreateElement originalType="code" className="language-java">
+            code example B
+          </MockMDXCreateElement>
+        </MockMDXCreateElement>,
+
+        <MockMDXCreateElement originalType="p">
+          paragraph text
+        </MockMDXCreateElement>,
+
+        <MockMDXCreateElement originalType="pre">
+          <MockMDXCreateElement originalType="code" className="language-php">
+            code example C
+          </MockMDXCreateElement>
+          <MockMDXCreateElement originalType="code" className="language-java">
+            code example D
+          </MockMDXCreateElement>
+        </MockMDXCreateElement>,
+      ],
+      into: MockCodeExamples,
+    })
+  ).toMatchSnapshot();
+});

--- a/components/util/groupCodeExamples.tsx
+++ b/components/util/groupCodeExamples.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable react/no-array-index-key */
+import { Children, cloneElement } from "react";
+
+const getLanguage = (el) =>
+  el.props.originalType === "pre" &&
+  (Children.toArray(el.props.children).find(
+    (c: any) =>
+      c.props.originalType === "code" &&
+      c.props.className?.startsWith("language-")
+  ) as any)?.props?.className?.replace("language-", "");
+
+const containsCode = (el) => !!getLanguage(el);
+
+export default function groupCodeExamples({
+  into: Component,
+  children,
+}: {
+  into: any;
+  children: any;
+}): JSX.Element {
+  const grouped = Children.toArray(children).reduce(
+    (acc: any, next: any, i) => {
+      if (acc === null) {
+        return [
+          containsCode(next) ? (
+            <Component key={i}>{next}</Component>
+          ) : (
+            cloneElement(next, { key: i })
+          ),
+        ];
+      }
+
+      const [head, last] = [acc.slice(0, acc.length - 1), acc[acc.length - 1]];
+
+      const tail =
+        last.type === Component && containsCode(next)
+          ? [
+              cloneElement(last, {
+                children: [...Children.toArray(last.props.children), next],
+              }),
+            ]
+          : [
+              last,
+              containsCode(next) ? (
+                <Component key={i}>{next}</Component>
+              ) : (
+                cloneElement(next, { key: i })
+              ),
+            ];
+
+      return [...head, ...tail];
+    },
+    null
+  );
+
+  return grouped as JSX.Element;
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import { LanguageContext } from "../components/util/Contexts";
 import AuthPage from "../components/AuthPage";
 import fetcher from "../modules/fetcher";
 import { MDXTypographyWrapper } from "../components/base/Typography";
+import groupCodeExamples from "../components/util/groupCodeExamples";
 
 const STATUS_PAGE_SUMMARY_URL =
   "https://tnynfs0nwlgr.statuspage.io/api/v2/summary.json";
@@ -92,7 +93,17 @@ const LANGUAGE_OPTIONS = [
 const MDX_COMPONENTS = {
   wrapper: ({ children }: { children: any }) => (
     <MDXTypographyWrapper>
-      <AnchorsSetter>{children}</AnchorsSetter>
+      <AnchorsSetter>
+        {groupCodeExamples({
+          children,
+          into: ({ children: c }: any) => (
+            <>
+              <h3>code examples</h3>
+              {c}
+            </>
+          ),
+        })}
+      </AnchorsSetter>
     </MDXTypographyWrapper>
   ),
 };


### PR DESCRIPTION
I ended up making this a function, since both AnchorSetter and GroupCodeExamples would expect an MDX document as its `children` and when it's a component it screws up AnchorSetter. There's probably a way we could make this a component as well, but for now this seemed simpler.

Usage:

```tsx
groupCodeExamples({
  children,
  into: ({ children: c }: any) => ( // eventually replace this with a `CodeExamples` component
    <>
      <h3>code examples</h3>
      {c}
    </>
  ),
})
```