### PR TITLE
WEB-610: Add breakpoints and refactor to make them clearer to use

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*]
+indent_style = space
+end_of_line = lf
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/components/__tests__/__snapshots__/breakpoints.test.ts.snap
+++ b/components/__tests__/__snapshots__/breakpoints.test.ts.snap
@@ -2,10 +2,7 @@
 
 exports[`breakpoints 1`] = `
 Object {
-  "BREAKPOINT_DESKTOP": 1024,
-  "BREAKPOINT_IPAD": 768,
-  "BREAKPOINT_MOBILE": 576,
-  "maxWidth": [Function],
-  "minWidth": [Function],
+  "breakDown": [Function],
+  "breakUp": [Function],
 }
 `;

--- a/components/base/Banner.tsx
+++ b/components/base/Banner.tsx
@@ -3,7 +3,7 @@ import classnames from "../../modules/classnames";
 import Button from "./Button";
 import { PURPLE_DARK, WHITE_PRIMARY, GREY_4 } from "../colors";
 import { POPPINS, ROBOTO } from "../typography";
-import { maxWidth, BREAKPOINT_IPAD, BREAKPOINT_MOBILE } from "../breakpoints";
+import { breakDown } from "../breakpoints";
 
 // Styled Banner component
 const StyledBanner = styled.div`
@@ -34,11 +34,11 @@ const StyledTopic = styled.div`
   font-weight: 200;
   line-height: 52px;
   text-align: center;
-  @media (${maxWidth(BREAKPOINT_IPAD)}) {
+  @media (${breakDown("sm")}) {
     font-size: 30px;
     line-height: 46px;
   }
-  @media (${maxWidth(BREAKPOINT_MOBILE)}) {
+  @media (${breakDown("xs")}) {
     font-size: 22px;
     line-height: 33px;
   }
@@ -54,7 +54,7 @@ const StyledDescription = styled.div`
   &.filters {
     margin-bottom: 52px;
   }
-  @media (${maxWidth(BREAKPOINT_IPAD)}) {
+  @media (${breakDown("sm")}) {
     font-size: 16px;
     line-height: 20px;
   }

--- a/components/base/Card.tsx
+++ b/components/base/Card.tsx
@@ -12,7 +12,7 @@ import {
 } from "../colors";
 import { BOX_SHADOW_4 } from "../shadowDepths";
 import { ROBOTO, POPPINS } from "../typography";
-import { maxWidth, BREAKPOINT_MOBILE } from "../breakpoints";
+import { breakDown } from "../breakpoints";
 
 type Props = {
   link?: boolean;
@@ -69,7 +69,7 @@ const CardStyle = styled.div`
     padding: 0px;
     position: relative;
     text-align: center;
-    @media (${maxWidth(BREAKPOINT_MOBILE)}) {
+    @media (${breakDown("xs")}) {
       width: 100%;
     }
   }

--- a/components/base/CardGrid.tsx
+++ b/components/base/CardGrid.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { maxWidth, BREAKPOINT_IPAD, BREAKPOINT_MOBILE } from "../breakpoints";
+import { breakDown } from "../breakpoints";
 
 const StyledGrid = styled.div`
   display: flex;
@@ -9,13 +9,13 @@ const StyledGrid = styled.div`
 const CardWrapper = styled.div`
   width: 25%;
   padding: 15px;
-  @media (${maxWidth(1600)}) {
+  @media (${breakDown("xl")}) {
     width: 33.3%;
   }
-  @media (${maxWidth(BREAKPOINT_IPAD)}) {
+  @media (${breakDown("sm")}) {
     width: 50%;
   }
-  @media (${maxWidth(BREAKPOINT_MOBILE)}) {
+  @media (${breakDown("xs")}) {
     width: 100%;
   }
 

--- a/components/base/FilterTabs.tsx
+++ b/components/base/FilterTabs.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import Select from "./select/Select";
 import { GREY_4, WHITE_PRIMARY, ORANGE_PRIMARY } from "../colors";
 import { POPPINS } from "../typography";
-import { minWidth, maxWidth, BREAKPOINT_MOBILE } from "../breakpoints";
+import { breakUp, breakDown } from "../breakpoints";
 import classnames from "../../modules/classnames";
 import { slugify } from "../../modules/helpers";
 
@@ -13,7 +13,7 @@ const TabsContainerStyle = styled.div`
   display: grid;
   grid-auto-flow: column;
   grid-column-gap: 30px;
-  @media (${maxWidth(BREAKPOINT_MOBILE)}) {
+  @media (${breakDown("xs")}) {
     display: none;
   }
 `;
@@ -43,7 +43,7 @@ export const TabStyle = styled.div`
 const SelectWrapper = styled.div`
   width: 150px;
   padding-bottom: 10px;
-  @media (${minWidth(BREAKPOINT_MOBILE)}) {
+  @media (${breakUp("sm")}) {
     display: none;
   }
 `;

--- a/components/base/FooterCTA.tsx
+++ b/components/base/FooterCTA.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import Button from "./Button";
 import { PURPLE_DARK } from "../colors";
 import { H2, SubHeader } from "./Typography";
-import { maxWidth, BREAKPOINT_IPAD, BREAKPOINT_MOBILE } from "../breakpoints";
+import { breakDown } from "../breakpoints";
 
 // Styles
 
@@ -14,7 +14,7 @@ const Container = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  @media (${maxWidth(BREAKPOINT_MOBILE)}) {
+  @media (${breakDown("xs")}) {
     padding: 20px;
     flex-direction: column;
   }
@@ -26,13 +26,13 @@ const StyledContent = styled.div`
     margin: 0;
     margin-bottom: 13px;
   }
-  @media (${maxWidth(BREAKPOINT_MOBILE)}) {
+  @media (${breakDown("xs")}) {
     margin-bottom: 15px;
     padding-right: unset;
     text-align: center;
   }
   /* Text sizes decrease in smaller screens */
-  @media (${maxWidth(BREAKPOINT_IPAD)}) {
+  @media (${breakDown("sm")}) {
     > * {
       margin-bottom: 7px;
     }

--- a/components/base/Pagination.tsx
+++ b/components/base/Pagination.tsx
@@ -6,7 +6,7 @@ import arrowRight from "../../assets/images/component-icons/arrow-right.svg";
 import { GREY_2, GREY_5, GREY_6, WHITE_PRIMARY } from "../colors";
 import { BOX_SHADOW_5 } from "../shadowDepths";
 import { ROBOTO, POPPINS } from "../typography";
-import { minWidth, BREAKPOINT_MOBILE } from "../breakpoints";
+import { breakUp } from "../breakpoints";
 
 // Styles
 const StyledAnchor = styled.a`
@@ -41,7 +41,7 @@ const Container = styled.div`
     margin-right: 15px;
   }
 
-  @media (${minWidth(BREAKPOINT_MOBILE)}) {
+  @media (${breakUp("sm")}) {
     width: 200px;
   }
 `;

--- a/components/base/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/components/base/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`Banner - no icon 1`] = `
   className=" css-1cx8r1g-StyledBanner eyaavg40"
 >
   <div
-    className="css-1hg7ivq-StyledTopic eyaavg42"
+    className="css-1ctbztb-StyledTopic eyaavg42"
   >
     Comprehensive API documentation for developers and businesses.
   </div>
   <div
-    className=" css-hiwaf6-StyledDescription eyaavg43"
+    className=" css-qmg3be-StyledDescription eyaavg43"
   >
     Step-by-step instructions to get you set up in the Dwolla API
   </div>
@@ -22,12 +22,12 @@ exports[`Banner - with Button 1`] = `
   className=" css-1cx8r1g-StyledBanner eyaavg40"
 >
   <div
-    className="css-1hg7ivq-StyledTopic eyaavg42"
+    className="css-1ctbztb-StyledTopic eyaavg42"
   >
     Comprehensive API documentation for developers and businesses.
   </div>
   <div
-    className=" css-hiwaf6-StyledDescription eyaavg43"
+    className=" css-qmg3be-StyledDescription eyaavg43"
   >
     Step-by-step instructions to get you set up in the Dwolla API
   </div>
@@ -50,12 +50,12 @@ exports[`Banner - with Filters 1`] = `
     src="test-image-stub"
   />
   <div
-    className="css-1hg7ivq-StyledTopic eyaavg42"
+    className="css-1ctbztb-StyledTopic eyaavg42"
   >
     Guides
   </div>
   <div
-    className="filters css-hiwaf6-StyledDescription eyaavg43"
+    className="filters css-qmg3be-StyledDescription eyaavg43"
   >
     Step-by-step instructions to get you set up in the Dwolla API
   </div>
@@ -64,7 +64,7 @@ exports[`Banner - with Filters 1`] = `
   >
     <div>
       <div
-        className="css-9vpk5d-TabsContainerStyle efq5uj30"
+        className="css-18c9go6-TabsContainerStyle efq5uj30"
       >
         <div
           className="tab is-active css-ptatp0-TabStyle efq5uj31"
@@ -92,7 +92,7 @@ exports[`Banner - with Filters 1`] = `
         </div>
       </div>
       <div
-        className="css-1ebuoxl-SelectWrapper efq5uj32"
+        className="css-n6mzzn-SelectWrapper efq5uj32"
       >
         <div
           className=" css-2b097c-container"
@@ -161,12 +161,12 @@ exports[`Default Banner 1`] = `
     src="test-image-stub"
   />
   <div
-    className="css-1hg7ivq-StyledTopic eyaavg42"
+    className="css-1ctbztb-StyledTopic eyaavg42"
   >
     Guides
   </div>
   <div
-    className=" css-hiwaf6-StyledDescription eyaavg43"
+    className=" css-qmg3be-StyledDescription eyaavg43"
   >
     Step-by-step instructions to get you set up in the Dwolla API
   </div>

--- a/components/base/__tests__/__snapshots__/Card.test.tsx.snap
+++ b/components/base/__tests__/__snapshots__/Card.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`default 1`] = `
 <div
-  className=" css-qhvpk8-CardStyle eguc8hf0"
+  className=" css-rz7fbh-CardStyle eguc8hf0"
 >
   <img
     alt=""
@@ -24,7 +24,7 @@ exports[`default 1`] = `
 
 exports[`with Badge 1`] = `
 <div
-  className=" css-qhvpk8-CardStyle eguc8hf0"
+  className=" css-rz7fbh-CardStyle eguc8hf0"
 >
   <img
     alt=""
@@ -55,7 +55,7 @@ exports[`with Badge 1`] = `
 
 exports[`with Center Align 1`] = `
 <div
-  className="center css-qhvpk8-CardStyle eguc8hf0"
+  className="center css-rz7fbh-CardStyle eguc8hf0"
 >
   <img
     alt=""
@@ -77,7 +77,7 @@ exports[`with Center Align 1`] = `
 
 exports[`with Center Align and Badge 1`] = `
 <div
-  className="center css-qhvpk8-CardStyle eguc8hf0"
+  className="center css-rz7fbh-CardStyle eguc8hf0"
 >
   <img
     alt=""
@@ -108,7 +108,7 @@ exports[`with Center Align and Badge 1`] = `
 
 exports[`with Center Align and Link 1`] = `
 <div
-  className="center css-qhvpk8-CardStyle eguc8hf0"
+  className="center css-rz7fbh-CardStyle eguc8hf0"
 >
   <img
     alt=""
@@ -137,7 +137,7 @@ exports[`with Center Align and Link 1`] = `
 
 exports[`with Center Align, Link and Badge 1`] = `
 <div
-  className="center css-qhvpk8-CardStyle eguc8hf0"
+  className="center css-rz7fbh-CardStyle eguc8hf0"
 >
   <img
     alt=""
@@ -175,7 +175,7 @@ exports[`with Center Align, Link and Badge 1`] = `
 
 exports[`with Link 1`] = `
 <div
-  className=" css-qhvpk8-CardStyle eguc8hf0"
+  className=" css-rz7fbh-CardStyle eguc8hf0"
 >
   <img
     alt=""
@@ -204,7 +204,7 @@ exports[`with Link 1`] = `
 
 exports[`with Link and Badge 1`] = `
 <div
-  className=" css-qhvpk8-CardStyle eguc8hf0"
+  className=" css-rz7fbh-CardStyle eguc8hf0"
 >
   <img
     alt=""

--- a/components/base/__tests__/__snapshots__/CardGrid.test.tsx.snap
+++ b/components/base/__tests__/__snapshots__/CardGrid.test.tsx.snap
@@ -5,10 +5,10 @@ exports[`CardGrid 1`] = `
   className="css-1vq1bk2-StyledGrid e1k3ap260"
 >
   <div
-    className="css-18v8ewl-CardWrapper e1k3ap261"
+    className="css-wbod5t-CardWrapper e1k3ap261"
   >
     <div
-      className=" css-qhvpk8-CardStyle eguc8hf0"
+      className=" css-rz7fbh-CardStyle eguc8hf0"
     >
       <img
         alt=""
@@ -28,10 +28,10 @@ exports[`CardGrid 1`] = `
     </div>
   </div>
   <div
-    className="css-18v8ewl-CardWrapper e1k3ap261"
+    className="css-wbod5t-CardWrapper e1k3ap261"
   >
     <div
-      className=" css-qhvpk8-CardStyle eguc8hf0"
+      className=" css-rz7fbh-CardStyle eguc8hf0"
     >
       <img
         alt=""
@@ -51,10 +51,10 @@ exports[`CardGrid 1`] = `
     </div>
   </div>
   <div
-    className="css-18v8ewl-CardWrapper e1k3ap261"
+    className="css-wbod5t-CardWrapper e1k3ap261"
   >
     <div
-      className=" css-qhvpk8-CardStyle eguc8hf0"
+      className=" css-rz7fbh-CardStyle eguc8hf0"
     >
       <img
         alt=""
@@ -74,10 +74,10 @@ exports[`CardGrid 1`] = `
     </div>
   </div>
   <div
-    className="css-18v8ewl-CardWrapper e1k3ap261"
+    className="css-wbod5t-CardWrapper e1k3ap261"
   >
     <div
-      className=" css-qhvpk8-CardStyle eguc8hf0"
+      className=" css-rz7fbh-CardStyle eguc8hf0"
     >
       <img
         alt=""
@@ -97,10 +97,10 @@ exports[`CardGrid 1`] = `
     </div>
   </div>
   <div
-    className="css-18v8ewl-CardWrapper e1k3ap261"
+    className="css-wbod5t-CardWrapper e1k3ap261"
   >
     <div
-      className=" css-qhvpk8-CardStyle eguc8hf0"
+      className=" css-rz7fbh-CardStyle eguc8hf0"
     >
       <img
         alt=""
@@ -120,10 +120,10 @@ exports[`CardGrid 1`] = `
     </div>
   </div>
   <div
-    className="css-18v8ewl-CardWrapper e1k3ap261"
+    className="css-wbod5t-CardWrapper e1k3ap261"
   >
     <div
-      className=" css-qhvpk8-CardStyle eguc8hf0"
+      className=" css-rz7fbh-CardStyle eguc8hf0"
     >
       <img
         alt=""
@@ -143,10 +143,10 @@ exports[`CardGrid 1`] = `
     </div>
   </div>
   <div
-    className="css-18v8ewl-CardWrapper e1k3ap261"
+    className="css-wbod5t-CardWrapper e1k3ap261"
   >
     <div
-      className=" css-qhvpk8-CardStyle eguc8hf0"
+      className=" css-rz7fbh-CardStyle eguc8hf0"
     >
       <img
         alt=""
@@ -166,10 +166,10 @@ exports[`CardGrid 1`] = `
     </div>
   </div>
   <div
-    className="css-18v8ewl-CardWrapper e1k3ap261"
+    className="css-wbod5t-CardWrapper e1k3ap261"
   >
     <div
-      className=" css-qhvpk8-CardStyle eguc8hf0"
+      className=" css-rz7fbh-CardStyle eguc8hf0"
     >
       <img
         alt=""

--- a/components/base/__tests__/__snapshots__/FilterTabs.test.tsx.snap
+++ b/components/base/__tests__/__snapshots__/FilterTabs.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FilterTabs 1`] = `
 <div>
   <div
-    className="css-9vpk5d-TabsContainerStyle efq5uj30"
+    className="css-18c9go6-TabsContainerStyle efq5uj30"
   >
     <div
       className="tab is-active css-ptatp0-TabStyle efq5uj31"
@@ -31,7 +31,7 @@ exports[`FilterTabs 1`] = `
     </div>
   </div>
   <div
-    className="css-1ebuoxl-SelectWrapper efq5uj32"
+    className="css-n6mzzn-SelectWrapper efq5uj32"
   >
     <div
       className=" css-2b097c-container"

--- a/components/base/__tests__/__snapshots__/FooterCTA.test.tsx.snap
+++ b/components/base/__tests__/__snapshots__/FooterCTA.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`FooterCTA 1`] = `
 <div
-  className="css-15t6xzt-Container exx89mw0"
+  className="css-1a9nbxj-Container exx89mw0"
 >
   <div
-    className="css-8ne3cr-StyledContent exx89mw1"
+    className="css-16d8gvv-StyledContent exx89mw1"
   >
     <h2
       className="dark css-626giu-global-global-h2"

--- a/components/base/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/components/base/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Pagination next 1`] = `
   onMouseEnter={[Function]}
 >
   <div
-    className="next css-bvk2s8-Container eutkdkv1"
+    className="next css-1gihvz6-Container eutkdkv1"
   >
     <div
       className="css-195yjlt-ArrowDiv eutkdkv2"
@@ -35,7 +35,7 @@ exports[`Pagination previous 1`] = `
   onMouseEnter={[Function]}
 >
   <div
-    className="previous css-bvk2s8-Container eutkdkv1"
+    className="previous css-1gihvz6-Container eutkdkv1"
   >
     <div
       className="css-195yjlt-ArrowDiv eutkdkv2"

--- a/components/breakpoints.ts
+++ b/components/breakpoints.ts
@@ -1,49 +1,51 @@
+type Breakpoint = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
+
 // <: extra small devices - portrait phones
-const BREAKPOINT_1 = 576;
+const BREAKPOINT_576 = 576;
 // > <: small devices - landscape phones
-const BREAKPOINT_2 = 768;
+const BREAKPOINT_768 = 768;
 // > <: medium devices - tablets
-const BREAKPOINT_3 = 992;
+const BREAKPOINT_992 = 992;
 // > <: large devices - desktops
-const BREAKPOINT_4 = 1200;
+const BREAKPOINT_1200 = 1200;
 // > <: extra large devices - large desktops, etc.
-const BREAKPOINT_5 = 1600;
+const BREAKPOINT_1600 = 1600;
 // >: extra extra large devices - Big McLargeHuge devices
 
-function breakUpPx(breakpoint) {
-  switch (breakpoint) {
+function breakUpPx(bpt: Breakpoint): number {
+  switch (bpt) {
     case "sm":
-      return BREAKPOINT_1;
+      return BREAKPOINT_576;
     case "md":
-      return BREAKPOINT_2;
+      return BREAKPOINT_768;
     case "lg":
-      return BREAKPOINT_3;
+      return BREAKPOINT_992;
     case "xl":
-      return BREAKPOINT_4;
+      return BREAKPOINT_1200;
     case "xxl":
-      return BREAKPOINT_5;
+      return BREAKPOINT_1600;
     default:
-      return breakpoint;
+      return 0;
   }
 }
 
-function breakDownPx(breakpoint) {
-  switch (breakpoint) {
+function breakDownPx(bpt: Breakpoint): number {
+  switch (bpt) {
     case "xs":
-      return BREAKPOINT_1;
+      return BREAKPOINT_576;
     case "sm":
-      return BREAKPOINT_2;
+      return BREAKPOINT_768;
     case "md":
-      return BREAKPOINT_3;
+      return BREAKPOINT_992;
     case "lg":
-      return BREAKPOINT_4;
+      return BREAKPOINT_1200;
     case "xl":
-      return BREAKPOINT_5;
+      return BREAKPOINT_1600;
     default:
-      return breakpoint;
+      return 0;
   }
 }
 
-export const breakUp = (breakpoint) => `min-width: ${breakUpPx(breakpoint)}px`;
-export const breakDown = (breakpoint) =>
-  `max-width: ${breakDownPx(breakpoint) - 0.02}px`;
+export const breakUp = (bpt: Breakpoint) => `min-width: ${breakUpPx(bpt)}px`;
+export const breakDown = (bpt: Breakpoint) =>
+  `max-width: ${breakDownPx(bpt) - 0.02}px`;

--- a/components/breakpoints.ts
+++ b/components/breakpoints.ts
@@ -1,6 +1,49 @@
-export const maxWidth = (breakpoint) => `max-width: ${breakpoint}px`;
-export const minWidth = (breakpoint) => `min-width: ${breakpoint + 1}px`;
+// <: extra small devices - portrait phones
+const BREAKPOINT_1 = 576;
+// > <: small devices - landscape phones
+const BREAKPOINT_2 = 768;
+// > <: medium devices - tablets
+const BREAKPOINT_3 = 992;
+// > <: large devices - desktops
+const BREAKPOINT_4 = 1200;
+// > <: extra large devices - large desktops, etc.
+const BREAKPOINT_5 = 1600;
+// >: extra extra large devices - Big McLargeHuge devices
 
-export const BREAKPOINT_DESKTOP = 1024;
-export const BREAKPOINT_IPAD = 768;
-export const BREAKPOINT_MOBILE = 576;
+function breakUpPx(breakpoint) {
+  switch (breakpoint) {
+    case "sm":
+      return BREAKPOINT_1;
+    case "md":
+      return BREAKPOINT_2;
+    case "lg":
+      return BREAKPOINT_3;
+    case "xl":
+      return BREAKPOINT_4;
+    case "xxl":
+      return BREAKPOINT_5;
+    default:
+      return breakpoint;
+  }
+}
+
+function breakDownPx(breakpoint) {
+  switch (breakpoint) {
+    case "xs":
+      return BREAKPOINT_1;
+    case "sm":
+      return BREAKPOINT_2;
+    case "md":
+      return BREAKPOINT_3;
+    case "lg":
+      return BREAKPOINT_4;
+    case "xl":
+      return BREAKPOINT_5;
+    default:
+      return breakpoint;
+  }
+}
+
+export const breakUp = (breakpoint) => `min-width: ${breakUpPx(breakpoint)}px`;
+export const breakDown = (breakpoint) =>
+  `max-width: ${breakDownPx(breakpoint) - 0.02}px`;

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -2,14 +2,14 @@ import styled from "@emotion/styled";
 import map from "lodash.map";
 import { GREY_2, HEADLINE_TEXT, PARAGRAPH_TEXT } from "../colors";
 import { POPPINS, ROBOTO } from "../typography";
-import { minWidth, BREAKPOINT_DESKTOP } from "../breakpoints";
+import { breakUp } from "../breakpoints";
 
 const Container = styled.div`
   border-top: 1px solid ${GREY_2};
   display: flex;
   flex-wrap: wrap;
 
-  @media (${minWidth(BREAKPOINT_DESKTOP)}) {
+  @media (${breakUp("lg")}) {
     padding: 20px;
   }
 `;
@@ -17,7 +17,7 @@ const Container = styled.div`
 const Group = styled.div`
   padding: 20px;
 
-  @media (${minWidth(BREAKPOINT_DESKTOP)}) {
+  @media (${breakUp("lg")}) {
     width: 200px;
   }
 `;

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -8,12 +8,7 @@ import classnames from "classnames";
 import { useState } from "react";
 import SideNav, { SideNavLinkProps } from "./SideNav"; // eslint-disable-line no-unused-vars
 import { GREY_2, WHITE_PRIMARY } from "../colors";
-import {
-  maxWidth,
-  minWidth,
-  BREAKPOINT_DESKTOP,
-  BREAKPOINT_IPAD,
-} from "../breakpoints";
+import { breakDown, breakUp } from "../breakpoints";
 import TopBar, { TOP_BAR_HEIGHT, TopBarProps } from "./TopBar"; // eslint-disable-line no-unused-vars
 import Footer, { FooterLink } from "./Footer"; // eslint-disable-line no-unused-vars
 import OnThisPage from "./OnThisPage";
@@ -37,7 +32,7 @@ const LeftSidebar = styled.div`
   transform: translate3d(0, -100vh, 0);
   z-index: 9999;
 
-  @media (${minWidth(BREAKPOINT_DESKTOP)}) {
+  @media (${breakUp("lg")}) {
     right: 75%;
     transform: translate3d(0, 0, 0);
   }
@@ -61,7 +56,7 @@ const SideNavWrapper = styled.div`
 `;
 
 const MainArea = styled.div`
-  @media (${minWidth(BREAKPOINT_DESKTOP)}) {
+  @media (${breakUp("lg")}) {
     margin-left: 25%;
   }
 `;
@@ -69,7 +64,7 @@ const MainArea = styled.div`
 const ContentArea = styled.div`
   display: flex;
 
-  @media (${minWidth(BREAKPOINT_DESKTOP)}) {
+  @media (${breakUp("lg")}) {
     margin-right: 40px;
   }
 `;
@@ -92,7 +87,7 @@ const OnThisPageWrapper = styled.div`
     display: none;
   }
 
-  @media (${maxWidth(BREAKPOINT_IPAD)}) {
+  @media (${breakDown("sm")}) {
     display: none;
   }
 `;
@@ -162,7 +157,7 @@ export default function Layout({
               float: right;
               transform: translate3d(0, 15px, 0);
 
-              @media (${minWidth(BREAKPOINT_DESKTOP)}) {
+              @media (${breakUp("lg")}) {
                 display: none;
               }
             `}

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -9,7 +9,7 @@ import { POPPINS } from "../typography";
 import Button from "../base/Button";
 import Select from "../base/select/Select";
 import { LanguageContext } from "../util/Contexts";
-import { BREAKPOINT_DESKTOP, minWidth } from "../breakpoints";
+import { breakUp } from "../breakpoints";
 
 export const TOP_BAR_HEIGHT = 68;
 
@@ -116,7 +116,7 @@ const Hamburger = styled.div`
     #000 100%
   );
 
-  @media (${minWidth(BREAKPOINT_DESKTOP)}) {
+  @media (${breakUp("lg")}) {
     display: none;
   }
 `;

--- a/components/layout/__tests__/__snapshots__/Layout.test.tsx.snap
+++ b/components/layout/__tests__/__snapshots__/Layout.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`Layout 1`] = `
 Array [
   <div
-    className=" css-99ba7r-LeftSidebar eu5n9bq0"
+    className=" css-p9rgcl-LeftSidebar eu5n9bq0"
   >
     <div
       className="css-3xwi1s-LogoWrapper eu5n9bq1"
     >
       <img
         alt=""
-        className="css-5xnblz-Layout-Layout"
+        className="css-1o5w4ty-Layout-Layout"
         onClick={[Function]}
         src="test-image-stub"
       />
@@ -141,7 +141,7 @@ Array [
     </a>
   </div>,
   <div
-    className="css-173gxmw-MainArea eu5n9bq3"
+    className="css-10ow9ob-MainArea eu5n9bq3"
   >
     <div
       className="css-jrlzw3-TopBarWrapper eu5n9bq5"
@@ -245,13 +245,13 @@ Array [
           </button>
         </div>
         <div
-          className="css-ldxdar-Hamburger e1xhgpyy4"
+          className="css-mtvnhp-Hamburger e1xhgpyy4"
           onClick={[Function]}
         />
       </div>
     </div>
     <div
-      className="css-1uiuud6-ContentArea eu5n9bq4"
+      className="css-cwox9s-ContentArea eu5n9bq4"
     >
       <div
         className="css-hr4r9m-ContentWrapper eu5n9bq7"
@@ -261,17 +261,17 @@ Array [
         </div>
       </div>
       <div
-        className="css-f0jn62-OnThisPageWrapper eu5n9bq6"
+        className="css-hsezkm-OnThisPageWrapper eu5n9bq6"
       />
     </div>
     <div
       className="css-cdxnl8-FooterWrapper eu5n9bq8"
     >
       <div
-        className="css-1e12l9h-Container en8mxva0"
+        className="css-wxvhif-Container en8mxva0"
       >
         <div
-          className="css-t8a825-Group en8mxva1"
+          className="css-1tgn4b3-Group en8mxva1"
         >
           <h3
             className="css-p408ob-Heading en8mxva2"
@@ -334,7 +334,7 @@ Array [
           </ul>
         </div>
         <div
-          className="css-t8a825-Group en8mxva1"
+          className="css-1tgn4b3-Group en8mxva1"
         >
           <h3
             className="css-p408ob-Heading en8mxva2"
@@ -377,7 +377,7 @@ Array [
           </ul>
         </div>
         <div
-          className="css-t8a825-Group en8mxva1"
+          className="css-1tgn4b3-Group en8mxva1"
         >
           <h3
             className="css-p408ob-Heading en8mxva2"
@@ -420,7 +420,7 @@ Array [
           </ul>
         </div>
         <div
-          className="css-t8a825-Group en8mxva1"
+          className="css-1tgn4b3-Group en8mxva1"
         >
           <h3
             className="css-p408ob-Heading en8mxva2"
@@ -463,7 +463,7 @@ Array [
           </ul>
         </div>
         <div
-          className="css-t8a825-Group en8mxva1"
+          className="css-1tgn4b3-Group en8mxva1"
         >
           <h3
             className="css-p408ob-Heading en8mxva2"

--- a/components/partial/MDXStyleWrapper.tsx
+++ b/components/partial/MDXStyleWrapper.tsx
@@ -1,5 +1,5 @@
 import { css } from "@emotion/core";
-import { minWidth, BREAKPOINT_IPAD } from "../breakpoints";
+import { breakUp } from "../breakpoints";
 import {
   headingStyles,
   paragraphStyles,
@@ -14,7 +14,7 @@ const MDXStyleWrapper = ({ children }: { children: any }) => (
     css={css`
       padding: 20px;
 
-      @media (${minWidth(BREAKPOINT_IPAD)}) {
+      @media (${breakUp("md")}) {
         padding: 20px 40px;
       }
 

--- a/components/partial/__tests__/__snapshots__/IndexPageGrid.test.tsx.snap
+++ b/components/partial/__tests__/__snapshots__/IndexPageGrid.test.tsx.snap
@@ -14,12 +14,12 @@ Array [
         src="guides-icon.svg"
       />
       <div
-        className="css-1hg7ivq-StyledTopic eyaavg42"
+        className="css-1ctbztb-StyledTopic eyaavg42"
       >
         Guides
       </div>
       <div
-        className="filters css-hiwaf6-StyledDescription eyaavg43"
+        className="filters css-qmg3be-StyledDescription eyaavg43"
       >
         Step-by-step instructions to get you set up in the Dwolla API
       </div>
@@ -28,7 +28,7 @@ Array [
       >
         <div>
           <div
-            className="css-9vpk5d-TabsContainerStyle efq5uj30"
+            className="css-18c9go6-TabsContainerStyle efq5uj30"
           >
             <div
               className="tab is-active css-ptatp0-TabStyle efq5uj31"
@@ -44,7 +44,7 @@ Array [
             </div>
           </div>
           <div
-            className="css-1ebuoxl-SelectWrapper efq5uj32"
+            className="css-n6mzzn-SelectWrapper efq5uj32"
           >
             <div
               className=" css-2b097c-container"
@@ -109,7 +109,7 @@ Array [
       className="css-1vq1bk2-StyledGrid e1k3ap260"
     >
       <div
-        className="css-18v8ewl-CardWrapper e1k3ap261"
+        className="css-wbod5t-CardWrapper e1k3ap261"
       >
         <a
           href="/docs/guides/send-money"
@@ -117,7 +117,7 @@ Array [
           onMouseEnter={[Function]}
         >
           <div
-            className=" css-qhvpk8-CardStyle eguc8hf0"
+            className=" css-rz7fbh-CardStyle eguc8hf0"
           >
             <img
               alt=""
@@ -147,7 +147,7 @@ Array [
         </a>
       </div>
       <div
-        className="css-18v8ewl-CardWrapper e1k3ap261"
+        className="css-wbod5t-CardWrapper e1k3ap261"
       >
         <a
           href="/docs/guides/receive-money"
@@ -155,7 +155,7 @@ Array [
           onMouseEnter={[Function]}
         >
           <div
-            className=" css-qhvpk8-CardStyle eguc8hf0"
+            className=" css-rz7fbh-CardStyle eguc8hf0"
           >
             <img
               alt=""
@@ -185,7 +185,7 @@ Array [
         </a>
       </div>
       <div
-        className="css-18v8ewl-CardWrapper e1k3ap261"
+        className="css-wbod5t-CardWrapper e1k3ap261"
       >
         <a
           href="/docs/guides/transfer-money-between-users/obtain-access-token"
@@ -193,7 +193,7 @@ Array [
           onMouseEnter={[Function]}
         >
           <div
-            className=" css-qhvpk8-CardStyle eguc8hf0"
+            className=" css-rz7fbh-CardStyle eguc8hf0"
           >
             <img
               alt=""

--- a/components/partial/__tests__/__snapshots__/MDXStyleWrapper.test.tsx.snap
+++ b/components/partial/__tests__/__snapshots__/MDXStyleWrapper.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`MDXStyleWrapper 1`] = `
 <div
-  className="css-rfwm99-global-global-h1-h2-h3-h4-h5-baseTextStyles-baseTextStyles-paragraphStyles-paragraphStyles-codeStyles-codeStyles-imageStyles-imageStyles-linkStyles-linkStyles-baseTextStyles-baseTextStyles-listStyles-listStyles-imageStyles-imageStyles-MDXStyleWrapper-MDXStyleWrapper"
+  className="css-16711vv-global-global-h1-h2-h3-h4-h5-baseTextStyles-baseTextStyles-paragraphStyles-paragraphStyles-codeStyles-codeStyles-imageStyles-imageStyles-linkStyles-linkStyles-baseTextStyles-baseTextStyles-listStyles-listStyles-imageStyles-imageStyles-MDXStyleWrapper-MDXStyleWrapper"
 >
   <h1>
     This is wrapped in the MDX Style Wrapper

--- a/components/partial/__tests__/__snapshots__/NextBackPagination.test.tsx.snap
+++ b/components/partial/__tests__/__snapshots__/NextBackPagination.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Next/Back Pagination 1`] = `
     onMouseEnter={[Function]}
   >
     <div
-      className="previous css-bvk2s8-Container eutkdkv1"
+      className="previous css-1gihvz6-Container eutkdkv1"
     >
       <div
         className="css-195yjlt-ArrowDiv eutkdkv2"
@@ -36,7 +36,7 @@ exports[`Next/Back Pagination 1`] = `
     onMouseEnter={[Function]}
   >
     <div
-      className="next css-bvk2s8-Container eutkdkv1"
+      className="next css-1gihvz6-Container eutkdkv1"
     >
       <div
         className="css-195yjlt-ArrowDiv eutkdkv2"

--- a/layouts/guides.tsx
+++ b/layouts/guides.tsx
@@ -3,12 +3,12 @@ import { DefaultMDXWrapper } from "./index";
 import Pages from "../modules/pages";
 import Pagination from "../components/partial/NextBackPagination";
 import FooterCTA from "../components/base/FooterCTA";
-import { minWidth, BREAKPOINT_IPAD } from "../components/breakpoints";
+import { breakUp } from "../components/breakpoints";
 
 const StyledPagination = styled.div`
   margin: 20px;
 
-  @media (${minWidth(BREAKPOINT_IPAD)}) {
+  @media (${breakUp("md")}) {
     margin: 40px;
   }
 `;

--- a/stories/base/Pagination.stories.tsx
+++ b/stories/base/Pagination.stories.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "@emotion/styled";
 import { storiesOf } from "@storybook/react";
 import Paginaton from "../../components/base/Pagination";
-import { maxWidth, BREAKPOINT_MOBILE } from "../../components/breakpoints";
+import { breakDown } from "../../components/breakpoints";
 
 // Wrapper div to positiont the pagination links
 const PaginationWrapper = styled.div`
@@ -19,7 +19,8 @@ const PaginationWrapper = styled.div`
     justify-content: center;
   }
   /* Previous and Next boxes are stacked on a smaller screen */
-  @media (${maxWidth(BREAKPOINT_MOBILE)}) {
+
+  @media (${breakDown("xs")}) {
     flex-direction: column;
     a {
       margin: 10px 0;


### PR DESCRIPTION
This PR implements the breakpoints as Bootstrap-style functions that tell you a bit more about which screens you are targeting in both the up and down directions. It should be a bit safer to use and require fewer imports.