### PR TITLE
SideNav accessibility

### DIFF
--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -18,6 +18,7 @@ import { POPPINS, ROBOTO } from "../typography";
 import { BOX_SHADOW_6 } from "../shadowDepths";
 import {
   GREY_2,
+  GREY_8,
   WHITE_PRIMARY,
   ORANGE_PRIMARY,
   PURPLE_PRIMARY_BUTTON,
@@ -29,7 +30,7 @@ import { breakUp, breakDown } from "../breakpoints";
 import TopBar, { TopBarProps, TOP_BAR_HEIGHT } from "./TopBar"; // eslint-disable-line no-unused-vars
 import Footer, { FooterLink } from "./Footer"; // eslint-disable-line no-unused-vars
 import APIStatusBar from "./APIStatusBar";
-import closeIcon from "../../assets/images/component-icons/close.svg";
+import { ReactComponent as CloseIcon } from "../../assets/images/component-icons/close.svg";
 import dwollaDevLogo from "../../assets/images/dwolla-developers-logo.svg";
 
 export const LEFT_SIDEBAR_PADDING_X = "20px";
@@ -60,6 +61,13 @@ const LeftSidebar = styled.div`
     opacity: 1;
     pointer-events: auto;
   }
+
+  /* Hides sidebar on smaller screens when not toggled. Not tabbable when not in view  */
+  &.visuallyHidden {
+    @media (${breakDown("md")}) {
+      visibility: hidden;
+    }
+  }
 `;
 
 const LogoWrapper = styled.div`
@@ -85,6 +93,32 @@ const SideNavWrapper = styled.div`
   flex-direction: column;
 `;
 
+const StyledCloseIcon = styled.div`
+  cursor: pointer;
+  svg {
+    * {
+      fill: ${ORANGE_PRIMARY};
+    }
+  }
+
+  :hover,
+  &.isFocused {
+    svg {
+      * {
+        fill: ${GREY_8};
+      }
+    }
+  }
+
+  :focus {
+    outline: none;
+  }
+
+  @media (${breakUp("lg")}) {
+    display: none;
+  }
+`;
+
 const MainArea = styled.div`
   @media (${breakUp("lg")}) {
     margin-left: 25%;
@@ -94,6 +128,13 @@ const MainArea = styled.div`
 const ContentArea = styled.div`
   @media (${breakUp("lg")}) {
     margin-right: 40px;
+  }
+
+  /* Hides ContentArea on smaller screens when SideBar is toggled. Not tabbable when not in view  */
+  &.visuallyhidden {
+    @media (${breakDown("md")}) {
+      visibility: hidden;
+    }
   }
 `;
 
@@ -110,6 +151,13 @@ const FooterWrapper = styled.div`
 
   @media (${breakUp("xxl")}) {
     padding-right: 40px;
+  }
+
+  /* Hides FooterArea on smaller screens when SideBar is toggled. Not tabbable when not in view  */
+  &.visuallyhidden {
+    @media (${breakDown("md")}) {
+      visibility: hidden;
+    }
   }
 `;
 
@@ -131,6 +179,7 @@ export default function Layout({
   apiStatus: APIStatus;
 }) {
   const [sidebarToggled, setSidebarToggled] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
 
   useEffect(() => {
     if (document) {
@@ -146,6 +195,10 @@ export default function Layout({
 
   const showSidebar = () => setSidebarToggled(true);
   const hideSidebar = () => setSidebarToggled(false);
+
+  function onKeydown(e) {
+    if (e.key === "Enter") hideSidebar();
+  }
 
   const router = useRouter();
 
@@ -206,7 +259,9 @@ export default function Layout({
         <link rel="canonical" href={router?.pathname} />
       </Head>
 
-      <LeftSidebar className={classnames({ toggled: sidebarToggled })}>
+      <LeftSidebar
+        className={classnames(sidebarToggled ? "toggled" : "visuallyHidden")}
+      >
         <LogoWrapper>
           <Link href="/">
             <a>
@@ -226,19 +281,16 @@ export default function Layout({
             </a>
           </Link>
 
-          <img
-            src={closeIcon}
-            alt=""
+          <StyledCloseIcon
+            tabIndex={0}
+            className={classnames({ isFocused })}
             onClick={hideSidebar}
-            css={css`
-              width: 14px;
-              cursor: pointer;
-
-              @media (${breakUp("lg")}) {
-                display: none;
-              }
-            `}
-          />
+            onKeyDown={(keyPress) => onKeydown(keyPress)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+          >
+            <CloseIcon width={14} />
+          </StyledCloseIcon>
         </LogoWrapper>
 
         <SideNavWrapper>
@@ -257,9 +309,13 @@ export default function Layout({
           <TopBar {...topBarProps} onHamburgerClick={showSidebar} />
         </TopBarWrapper>
 
-        <ContentArea>{children}</ContentArea>
+        <ContentArea className={classnames({ visuallyhidden: sidebarToggled })}>
+          {children}
+        </ContentArea>
 
-        <FooterWrapper>
+        <FooterWrapper
+          className={classnames({ visuallyhidden: sidebarToggled })}
+        >
           <Footer links={footerLinks} legal={footerLegal} />
         </FooterWrapper>
       </MainArea>

--- a/components/layout/SideNav.tsx
+++ b/components/layout/SideNav.tsx
@@ -341,6 +341,11 @@ const MobileWrap = styled.div`
   @media (${breakUp("lg")}) {
     display: none;
   }
+
+  /* Hides MobileWrap contents when Sidebar is toggled and a Section is active. Not tabbable when not in view. */
+  &.visuallyhidden {
+    visibility: hidden;
+  }
 `;
 
 const MobileLink = ({ href, external, text, active }: MobileLinkProps) => {
@@ -443,7 +448,11 @@ const SideNav = ({ sectionLinks, pages, mobileItems }: SideNavProps) => {
             </SectionWrap>
           )}
 
-          <MobileWrap>
+          <MobileWrap
+            className={classnames({
+              visuallyhidden: activeSection && activeSection.isSection,
+            })}
+          >
             <MobileItems {...mobileItems} />
           </MobileWrap>
         </SlidePane>

--- a/components/layout/TopBar.tsx
+++ b/components/layout/TopBar.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import styled from "@emotion/styled";
 import classnames from "classnames";
 import Link from "next/link";
@@ -155,6 +155,15 @@ const Hamburger = styled.div`
   @media (${breakUp("lg")}) {
     display: none;
   }
+
+  :focus {
+    outline: none;
+  }
+
+  &:hover,
+  &.isFocused {
+    opacity: 0.5;
+  }
 `;
 
 export default function TopBar({
@@ -166,6 +175,11 @@ export default function TopBar({
     LanguageContext
   );
 
+  const [isFocused, setIsFocused] = useState(false);
+
+  function onHamburgerKeydown(e) {
+    if (e.key === "Enter") onHamburgerClick();
+  }
   const router = useRouter();
 
   return (
@@ -198,7 +212,17 @@ export default function TopBar({
         <Button {...button} size="standard" variant="primary" />
       </ButtonWrapper>
 
-      {onHamburgerClick && <Hamburger onClick={onHamburgerClick} />}
+      {onHamburgerClick && (
+        <Hamburger
+          tabIndex={0}
+          aria-labelledby="Open menu"
+          className={classnames({ isFocused })}
+          onClick={onHamburgerClick}
+          onKeyDown={(keyPress) => onHamburgerKeydown(keyPress)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+        />
+      )}
     </Container>
   );
 }

--- a/components/layout/__tests__/__snapshots__/Layout.test.tsx.snap
+++ b/components/layout/__tests__/__snapshots__/Layout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Layout 1`] = `
 Array [
   <div
-    className=" css-1e2mt3q-LeftSidebar eu5n9bq0"
+    className="visuallyHidden css-g3cfbj-LeftSidebar eu5n9bq0"
   >
     <div
       className="css-wvabyo-LogoWrapper eu5n9bq1"
@@ -19,12 +19,18 @@ Array [
           src="test-image-stub"
         />
       </a>
-      <img
-        alt=""
-        className="css-189x3u4-Layout-Layout"
+      <div
+        className=" css-3djgvj-StyledCloseIcon eu5n9bq3"
+        onBlur={[Function]}
         onClick={[Function]}
-        src="test-image-stub"
-      />
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        tabIndex={0}
+      >
+        <svg
+          width={14}
+        />
+      </div>
     </div>
     <div
       className="css-1exhr1v-SideNavWrapper eu5n9bq2"
@@ -127,7 +133,7 @@ Array [
               </a>
             </div>
             <div
-              className="css-nasyo1-MobileWrap e10mac9s12"
+              className=" css-1lx8d8l-MobileWrap e10mac9s12"
             >
               <a
                 className=" css-1twa2js-MobileLink-MobileLink"
@@ -193,10 +199,10 @@ Array [
     </a>
   </div>,
   <div
-    className="css-10ow9ob-MainArea eu5n9bq3"
+    className="css-10ow9ob-MainArea eu5n9bq4"
   >
     <div
-      className="css-jrlzw3-TopBarWrapper eu5n9bq5"
+      className="css-jrlzw3-TopBarWrapper eu5n9bq6"
     >
       <div
         className="css-16rtae5-Container e1xhgpyy0"
@@ -309,20 +315,25 @@ Array [
           </a>
         </div>
         <div
-          className="css-1gc2exo-Hamburger e1xhgpyy6"
+          aria-labelledby="Open menu"
+          className=" css-1artr2y-Hamburger e1xhgpyy6"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          tabIndex={0}
         />
       </div>
     </div>
     <div
-      className="css-gsovx7-ContentArea eu5n9bq4"
+      className=" css-r2kzr4-ContentArea eu5n9bq5"
     >
       <div>
         page
       </div>
     </div>
     <div
-      className="css-r8zrnm-FooterWrapper eu5n9bq6"
+      className=" css-1vo9m3u-FooterWrapper eu5n9bq7"
     >
       <div
         className="css-157ism8-Container en8mxva0"

--- a/components/layout/__tests__/__snapshots__/SideNav.test.tsx.snap
+++ b/components/layout/__tests__/__snapshots__/SideNav.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`SideNav 1`] = `
         </a>
       </div>
       <div
-        className="css-nasyo1-MobileWrap e10mac9s12"
+        className=" css-1lx8d8l-MobileWrap e10mac9s12"
       >
         <a
           className=" css-1twa2js-MobileLink-MobileLink"


### PR DESCRIPTION
- Made sidebar non-focusable on smaller screens when not toggled on smaller screens.
- Made Main content and footer area non-focusable when sidebar is toggled.
- Made Hamburger and Menu Close-icon tabbable/actionable.
- Added Hover/focus states to hamburger/close menu. 