### PR TITLE
Fixed height issues with select dropdown when inner text overflows on smaller screens

### DIFF
--- a/components/base/FilterTabs.tsx
+++ b/components/base/FilterTabs.tsx
@@ -49,7 +49,6 @@ export const TabStyle = styled.li`
 
 // Tabs are replaced with Select dropdown on mobile
 const SelectWrapper = styled.div`
-  width: 150px;
   padding-bottom: 10px;
   @media (${breakUp("sm")}) {
     display: none;
@@ -102,6 +101,7 @@ export default function FilterTabs({ tabs, filter, setFilter }: Props) {
           options={formattedTabs}
           selectedValue={formattedFilter}
           setSelectedValue={setFilter}
+          autoWidth
         />
       </SelectWrapper>
     </div>

--- a/components/base/__tests__/__snapshots__/Banner.test.tsx.snap
+++ b/components/base/__tests__/__snapshots__/Banner.test.tsx.snap
@@ -145,10 +145,10 @@ exports[`Banner - with Filters 1`] = `
         </li>
       </ul>
       <div
-        className="css-n6mzzn-SelectWrapper efq5uj32"
+        className="css-gj0wpv-SelectWrapper efq5uj32"
       >
         <div
-          className=" css-2b097c-container"
+          className=" css-k377xg-container"
           onKeyDown={[Function]}
         >
           <div
@@ -157,7 +157,7 @@ exports[`Banner - with Filters 1`] = `
             onTouchEnd={[Function]}
           >
             <div
-              className=" css-86rg1c-ValueContainer"
+              className=" css-15ikjri-ValueContainer"
             >
               <div
                 className=" css-1me8bqy-singleValue"

--- a/components/base/__tests__/__snapshots__/FilterTabs.test.tsx.snap
+++ b/components/base/__tests__/__snapshots__/FilterTabs.test.tsx.snap
@@ -39,10 +39,10 @@ exports[`FilterTabs 1`] = `
     </li>
   </ul>
   <div
-    className="css-n6mzzn-SelectWrapper efq5uj32"
+    className="css-gj0wpv-SelectWrapper efq5uj32"
   >
     <div
-      className=" css-2b097c-container"
+      className=" css-k377xg-container"
       onKeyDown={[Function]}
     >
       <div
@@ -51,7 +51,7 @@ exports[`FilterTabs 1`] = `
         onTouchEnd={[Function]}
       >
         <div
-          className=" css-86rg1c-ValueContainer"
+          className=" css-15ikjri-ValueContainer"
         >
           <div
             className=" css-1me8bqy-singleValue"

--- a/components/base/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/components/base/__tests__/__snapshots__/Select.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`AutoWidth Code Block Select 1`] = `
     onTouchEnd={[Function]}
   >
     <div
-      className=" css-86rg1c-ValueContainer"
+      className=" css-1fpxn2j-ValueContainer"
     >
       <div
         className=" css-gn3biy-singleValue"
@@ -64,7 +64,7 @@ exports[`AutoWidth Select 1`] = `
     onTouchEnd={[Function]}
   >
     <div
-      className=" css-86rg1c-ValueContainer"
+      className=" css-15ikjri-ValueContainer"
     >
       <div
         className=" css-1me8bqy-singleValue"
@@ -118,7 +118,7 @@ exports[`Code Block Select 1`] = `
     onTouchEnd={[Function]}
   >
     <div
-      className=" css-86rg1c-ValueContainer"
+      className=" css-1fpxn2j-ValueContainer"
     >
       <div
         className=" css-gn3biy-singleValue"
@@ -171,7 +171,7 @@ exports[`Default Select 1`] = `
     onTouchEnd={[Function]}
   >
     <div
-      className=" css-86rg1c-ValueContainer"
+      className=" css-15ikjri-ValueContainer"
     >
       <div
         className=" css-1me8bqy-singleValue"

--- a/components/base/select/Select.styles.tsx
+++ b/components/base/select/Select.styles.tsx
@@ -36,10 +36,6 @@ export const StyledSelectedIconWrap = styled.div`
 `;
 
 const sharedCustomStyles = {
-  valueContainer: (styles) => ({
-    ...styles,
-    padding: 0,
-  }),
   indicatorSeparator: (styles) => ({
     ...styles,
     display: "none",
@@ -61,6 +57,14 @@ export const defaultCustomStyles = {
     ":hover": {
       borderColor: GREY_4,
       color: GREY_6,
+    },
+  }),
+  valueContainer: (styles) => ({
+    ...styles,
+    padding: 0,
+    maxHeight: 30,
+    input: {
+      height: 0,
     },
   }),
   singleValue: (styles) => ({
@@ -140,6 +144,14 @@ export const codeCustomStyles = {
           fill: WHITE_PRIMARY,
         },
       },
+    },
+  }),
+  valueContainer: (styles) => ({
+    ...styles,
+    padding: 0,
+    maxHeight: 27,
+    input: {
+      height: 0,
     },
   }),
   singleValue: (styles) => ({

--- a/components/layout/__tests__/__snapshots__/Layout.test.tsx.snap
+++ b/components/layout/__tests__/__snapshots__/Layout.test.tsx.snap
@@ -266,7 +266,7 @@ Array [
               onTouchEnd={[Function]}
             >
               <div
-                className=" css-86rg1c-ValueContainer"
+                className=" css-15ikjri-ValueContainer"
               >
                 <div
                   className=" css-1me8bqy-singleValue"

--- a/components/layout/__tests__/__snapshots__/TopBar.test.tsx.snap
+++ b/components/layout/__tests__/__snapshots__/TopBar.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`TopBar 1`] = `
         onTouchEnd={[Function]}
       >
         <div
-          className=" css-86rg1c-ValueContainer"
+          className=" css-15ikjri-ValueContainer"
         >
           <div
             className=" css-1me8bqy-singleValue"

--- a/components/partial/__tests__/__snapshots__/IndexPageGrid.test.tsx.snap
+++ b/components/partial/__tests__/__snapshots__/IndexPageGrid.test.tsx.snap
@@ -52,10 +52,10 @@ Array [
             </li>
           </ul>
           <div
-            className="css-n6mzzn-SelectWrapper efq5uj32"
+            className="css-gj0wpv-SelectWrapper efq5uj32"
           >
             <div
-              className=" css-2b097c-container"
+              className=" css-k377xg-container"
               onKeyDown={[Function]}
             >
               <div
@@ -64,7 +64,7 @@ Array [
                 onTouchEnd={[Function]}
               >
                 <div
-                  className=" css-86rg1c-ValueContainer"
+                  className=" css-15ikjri-ValueContainer"
                 >
                   <div
                     className=" css-1me8bqy-singleValue"

--- a/components/partial/code/__tests__/__snapshots__/CodeExamples.test.tsx.snap
+++ b/components/partial/code/__tests__/__snapshots__/CodeExamples.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`multiple examples 1`] = `
         onTouchEnd={[Function]}
       >
         <div
-          className=" css-86rg1c-ValueContainer"
+          className=" css-1fpxn2j-ValueContainer"
         >
           <div
             className=" css-gn3biy-singleValue"


### PR DESCRIPTION
I ended up setting different max-heights for both variants of Select dropdowns.