### PR TITLE
Prevent nested onClick from triggering parent onClick

### DIFF
--- a/app/components/base/__tests__/__snapshots__/WebhookCodeBlock.test.tsx.snap
+++ b/app/components/base/__tests__/__snapshots__/WebhookCodeBlock.test.tsx.snap
@@ -76,6 +76,7 @@ exports[`WebhookCodeBlock 1`] = `
                   className="css-5uu5vc-CodeBlockButton e112hlxu5"
                   disabled={false}
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   type="button"
                 >
                   copy
@@ -86,6 +87,7 @@ exports[`WebhookCodeBlock 1`] = `
                   autoFocus={false}
                   className="css-5uu5vc-CodeBlockButton e112hlxu5"
                   onClick={[Function]}
+                  onKeyDown={[Function]}
                   type="button"
                 >
                   expand 

--- a/app/components/partial/code/CodeExamples.tsx
+++ b/app/components/partial/code/CodeExamples.tsx
@@ -109,9 +109,17 @@ export default function CodeExamples({
 
   const { copied, copy } = useCopy(codeString);
 
+  function onKeydownCopy(e) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      copy(e);
+    }
+  }
+
   const onlyOneExample = options.length === 1;
 
-  const toggleExpanded = () => {
+  const toggleExpanded = (e) => {
+    e.stopPropagation();
     if (!expanded) {
       setExpanded("expanded");
       disableBodyScroll();
@@ -123,6 +131,13 @@ export default function CodeExamples({
       }, 280);
     }
   };
+
+  function onKeydownExpand(e) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      toggleExpanded(e);
+    }
+  }
 
   type CodeBlockProps = {
     variant?: "default" | "fullscreen";
@@ -150,13 +165,19 @@ export default function CodeExamples({
             />
           )}
 
-          <CodeBlockButton type="button" onClick={copy} disabled={copied}>
+          <CodeBlockButton
+            type="button"
+            onClick={copy}
+            onKeyDown={(keyPress) => onKeydownCopy(keyPress)}
+            disabled={copied}
+          >
             {copied ? "copied" : "copy"} <CopyIcon />
           </CodeBlockButton>
 
           <CodeBlockButton
             type="button"
             onClick={toggleExpanded}
+            onKeyDown={(keyPress) => onKeydownExpand(keyPress)}
             autoFocus={variant === "fullscreen"}
           >
             {variant === "fullscreen" ? (

--- a/app/components/partial/code/__tests__/__snapshots__/CodeExamples.test.tsx.snap
+++ b/app/components/partial/code/__tests__/__snapshots__/CodeExamples.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`multiple examples 1`] = `
         className="css-5uu5vc-CodeBlockButton e112hlxu5"
         disabled={false}
         onClick={[Function]}
+        onKeyDown={[Function]}
         type="button"
       >
         copy
@@ -72,6 +73,7 @@ exports[`multiple examples 1`] = `
         autoFocus={false}
         className="css-5uu5vc-CodeBlockButton e112hlxu5"
         onClick={[Function]}
+        onKeyDown={[Function]}
         type="button"
       >
         expand 
@@ -117,6 +119,7 @@ exports[`single example 1`] = `
         className="css-5uu5vc-CodeBlockButton e112hlxu5"
         disabled={false}
         onClick={[Function]}
+        onKeyDown={[Function]}
         type="button"
       >
         copy
@@ -127,6 +130,7 @@ exports[`single example 1`] = `
         autoFocus={false}
         className="css-5uu5vc-CodeBlockButton e112hlxu5"
         onClick={[Function]}
+        onKeyDown={[Function]}
         type="button"
       >
         expand 
@@ -177,6 +181,7 @@ exports[`single example with title 1`] = `
         className="css-5uu5vc-CodeBlockButton e112hlxu5"
         disabled={false}
         onClick={[Function]}
+        onKeyDown={[Function]}
         type="button"
       >
         copy
@@ -187,6 +192,7 @@ exports[`single example with title 1`] = `
         autoFocus={false}
         className="css-5uu5vc-CodeBlockButton e112hlxu5"
         onClick={[Function]}
+        onKeyDown={[Function]}
         type="button"
       >
         expand 

--- a/app/hooks/useCopy.tsx
+++ b/app/hooks/useCopy.tsx
@@ -17,7 +17,8 @@ export default function useCopy(text, timeout = DEFAULT_TIMEOUT) {
     return () => clearTimeout(resetCopied);
   }, [copied]);
 
-  const copy = () => {
+  const copy = (e) => {
+    e.stopPropagation();
     navigator.clipboard.writeText(text);
     setCopied(true);
   };


### PR DESCRIPTION
What changed: 
- Added keyDown event to `Copy` and `Expand` blocks in CodeExamples to handle keyboard actions
- Prevented `onClick` and `onKeyDown` from triggering parent `onClick` (useful when using `<CodeExamples>` inside another component like `<Collapsible>`

What to test:
- Run `yarn storybook`
- Go to `<WebhookCodeBlock>`, open the collapsible and click on `Expand` or `Copy`
- Do the same using keyboard commands