### PR TITLE
Resolve some deprecation warnings before v10 upgrade

### DIFF
--- a/app/components/util/Anchors.tsx
+++ b/app/components/util/Anchors.tsx
@@ -1,11 +1,10 @@
 import {
-  createContext,
-  useState,
-  useEffect,
-  useContext,
   Children,
   cloneElement,
-  useLayoutEffect,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
 } from "react";
 import { useRouter } from "next/router";
 import GithubSlugger from "github-slugger";
@@ -95,7 +94,7 @@ export function AnchorsSetter(props) {
     };
   }, [router?.pathname]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     let raf: number;
     const anchorEls = anchors.map((a: Anchor) => document.getElementById(a.id));
 
@@ -131,7 +130,7 @@ export function AnchorsSetter(props) {
     };
   }, [router?.pathname]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (activeAnchor) {
       window.history.replaceState(
         null,

--- a/app/modules/highlight.ts
+++ b/app/modules/highlight.ts
@@ -1,4 +1,4 @@
-import hljs from "highlight.js/lib/core";
+import hljs from "highlight.js";
 
 export type Language =
   | "javascript"
@@ -44,5 +44,5 @@ registerLanguage("xml", require("highlight.js/lib/languages/xml"));
 hljs.registerLanguage("css", require("highlight.js/lib/languages/css"));
 
 export default function highlight(code: string, language: string) {
-  return hljs.highlight(language || "plaintext", code).value;
+  return hljs.highlight(code, { language: language || "plaintext" }).value;
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "classnames": "^2.2.6",
     "eslint-plugin-jest": "^23.8.2",
     "github-slugger": "^1.3.0",
-    "highlight.js": "^10.0.1",
+    "highlight.js": "^10.7.2",
     "identity-obj-proxy": "^3.0.0",
     "iframe-resizer-react": "1.0.3",
     "isomorphic-unfetch": "^3.0.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import App, { createUrl } from "next/app";
+import App, { AppProps } from "next/app";
 import useSWR from "swr";
 import TagManager from "react-gtm-module";
 import Layout from "../app/components/layout/Layout";
@@ -143,16 +143,14 @@ const LANGUAGE_OPTIONS = [
   { value: "bash", label: "Raw" },
 ];
 
-function AppWithHooks({ router, Component, pageProps }: any) {
+function AppWithHooks({ router, Component, pageProps }: AppProps) {
   const [selectedLanguage, setSelectedLanguage] = useState(LANGUAGE_OPTIONS[0]);
-
-  const url = createUrl(router);
 
   const apiStatus = useSWR(STATUS_PAGE_SUMMARY_URL, fetcher, {
     refreshInterval: 60000,
   }).data?.status;
 
-  useTrackPageViews(url.pathname);
+  useTrackPageViews(router.pathname);
 
   return (
     <AnchorsProvider>
@@ -172,7 +170,7 @@ function AppWithHooks({ router, Component, pageProps }: any) {
           topBarProps={TOP_BAR_PROPS}
           apiStatus={apiStatus}
         >
-          <Component {...pageProps} url={url} />
+          <Component {...pageProps} url={router.pathname} />
         </Layout>
       </LanguageContext.Provider>
     </AnchorsProvider>
@@ -181,7 +179,7 @@ function AppWithHooks({ router, Component, pageProps }: any) {
 
 export default class MyApp extends App {
   render() {
-    const { router, Component, pageProps } = this.props;
+    const { router, Component, pageProps }: AppProps = this.props;
     return (
       <>
         <GoogleTagManager />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7768,7 +7768,7 @@ he@1.2.0, he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highlight.js@^10.0.1:
+highlight.js@^10.7.2:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==


### PR DESCRIPTION
As dependencies have been updated, some deprecation warnings have occurred. This PR resolves the following:

- Next.js `url` property is now deprecated
- Prefer to use `useEffect()` versus `useLayoutEffect()` as `useLayoutEffect()` does nothing on the server
- Highlight.js slightly changed its API, preferring an options object to be passed in