### PR TITLE
DEV-830: Disable UCR Balance option in Transfer Workflow, and automatically disable Receiver until Sender is set

### DIFF
--- a/app/components/base/FundsFlowSelector.tsx
+++ b/app/components/base/FundsFlowSelector.tsx
@@ -195,7 +195,7 @@ function FundsFlowSelector({
         components={{ DropdownIndicator, Option }}
         placeholder="Select Receiver Destination"
         onChange={setSelectedDestination}
-        isDisabled={isReceiverDisabled}
+        isDisabled={!receiverDestinationOptions}
       />
     </StyledContainer>
   );

--- a/app/components/base/FundsFlowSelector.tsx
+++ b/app/components/base/FundsFlowSelector.tsx
@@ -144,6 +144,7 @@ type Props = {
   setSelectedSource: any;
   setSelectedReceiver: any;
   setSelectedDestination: any;
+  isReceiverDisabled?: boolean;
 };
 
 function FundsFlowSelector({
@@ -155,6 +156,7 @@ function FundsFlowSelector({
   setSelectedSource,
   setSelectedReceiver,
   setSelectedDestination,
+  isReceiverDisabled,
 }: Props) {
   return (
     <StyledContainer>
@@ -174,6 +176,7 @@ function FundsFlowSelector({
         components={{ DropdownIndicator, Option }}
         placeholder="Select Sender Source"
         onChange={setSelectedSource}
+        isDisabled={!senderSourceOptions}
       />
       <StyledTitle>Receiver:</StyledTitle>
       <StyledType>Receiver Type</StyledType>
@@ -183,6 +186,7 @@ function FundsFlowSelector({
         components={{ DropdownIndicator, Option }}
         placeholder="Select Receiver Type"
         onChange={setSelectedReceiver}
+        isDisabled={isReceiverDisabled}
       />
       <StyledType>Receiver Destination</StyledType>
       <Select
@@ -191,6 +195,7 @@ function FundsFlowSelector({
         components={{ DropdownIndicator, Option }}
         placeholder="Select Receiver Destination"
         onChange={setSelectedDestination}
+        isDisabled={isReceiverDisabled}
       />
     </StyledContainer>
   );

--- a/app/components/base/TransferWorkflow.tsx
+++ b/app/components/base/TransferWorkflow.tsx
@@ -134,9 +134,9 @@ const StyledBottomContainer = styled.div`
 // selectable options for FundsFlowSelector component
 
 const senderTypeOptions = [
-  { value: "account", label: "Account" },
-  { value: "vcr", label: "Verified Customer" },
-  { value: "cr", label: "Unverified Customer" },
+  { value: "account", label: "Account", sources: ["balance", "bank"] },
+  { value: "vcr", label: "Verified Customer", sources: ["balance", "bank"] },
+  { value: "cr", label: "Unverified Customer", sources: ["bank"] },
 ];
 
 const senderSourceOptions = [
@@ -196,6 +196,7 @@ const fundsFlowCombinations = {
 // TransferWorkflow component
 
 function TransferWorkflow() {
+  const [allowedSenderSources, setAllowedSenderSources] = useState(null);
   const [selectedSender, setSelectedSender] = useState(null);
   const [selectedSource, setSelectedSource] = useState(null);
   const [selectedReceiver, setSelectedReceiver] = useState(null);
@@ -206,6 +207,20 @@ function TransferWorkflow() {
   const [webhookJsonData, setWebhookJsonData] = useState<any | undefined>(
     undefined
   );
+
+  /**
+   * Update `allowedSenderSources` when a Sender Type updates. This will allow the
+   * Sender Source to get updated with only options that are allowed for a given workflow.
+   *
+   * For example, if the user selects Unverified Customer as their Sender Type, then only
+   * Bank should be shown as a Sender Source option, since Balance is would be an illegal value.
+   */
+  function handleSenderChanged(sender): void {
+    setSelectedSender(sender);
+    setAllowedSenderSources(
+      senderSourceOptions.filter(({ value }) => sender.sources.includes(value))
+    );
+  }
 
   // function to handle Start button
 
@@ -346,6 +361,7 @@ function TransferWorkflow() {
       setSelectedFundsFlow([]);
       setUnsupportedFundsFlow(false);
       setWebhookJsonData(undefined);
+      setAllowedSenderSources(null);
       setSelectedSender(null);
       setSelectedSource(null);
       setSelectedReceiver(null);
@@ -384,13 +400,14 @@ function TransferWorkflow() {
         // display FundsFlowSelector component when activeStep is 0
         <FundsFlowSelector
           senderTypeOptions={senderTypeOptions}
-          senderSourceOptions={senderSourceOptions}
+          senderSourceOptions={allowedSenderSources}
           receiverTypeOptions={receiverTypeOptions}
           receiverDestinationOptions={receiverDestinationOptions}
-          setSelectedSender={setSelectedSender}
+          setSelectedSender={handleSenderChanged}
           setSelectedSource={setSelectedSource}
           setSelectedReceiver={setSelectedReceiver}
           setSelectedDestination={setSelectedDestination}
+          isReceiverDisabled={!(selectedSender && selectedSource)}
         />
       ) : // check if Funds Flow is unsupported, otherwise display code block component
       unsupportedFundsFlow ? (

--- a/app/components/base/TransferWorkflow.tsx
+++ b/app/components/base/TransferWorkflow.tsx
@@ -137,19 +137,19 @@ const senderTypeOptions = [
   {
     value: "account",
     label: "Account",
-    sources: ["balance", "bank"],
+    hasSources: ["balance", "bank"],
     canTransactWith: ["vcr", "cr", "ro"],
   },
   {
     value: "vcr",
     label: "Verified Customer",
-    sources: ["balance", "bank"],
+    hasSources: ["balance", "bank"],
     canTransactWith: ["account", "vcr", "cr", "ro"],
   },
   {
     value: "cr",
     label: "Unverified Customer",
-    sources: ["bank"],
+    hasSources: ["bank"],
     canTransactWith: ["account", "vcr"],
   },
 ];
@@ -160,14 +160,14 @@ const senderSourceOptions = [
 ];
 
 const receiverTypeOptions = [
-  { value: "account", label: "Account", destinations: ["balance", "bank"] },
+  { value: "account", label: "Account", hasDestinations: ["balance", "bank"] },
   {
     value: "vcr",
     label: "Verified Customer",
-    destinations: ["balance", "bank"],
+    hasDestinations: ["balance", "bank"],
   },
-  { value: "cr", label: "Unverified Customer", destinations: ["bank"] },
-  { value: "ro", label: "Receive-Only User", destinations: ["bank"] },
+  { value: "cr", label: "Unverified Customer", hasDestinations: ["bank"] },
+  { value: "ro", label: "Receive-Only User", hasDestinations: ["bank"] },
 ];
 
 const receiverDestinationOptions = [
@@ -240,7 +240,9 @@ function TransferWorkflow() {
   function handleSenderChanged(sender): void {
     setSelectedSender(sender);
     setAllowedSenderSources(
-      senderSourceOptions.filter(({ value }) => sender.sources.includes(value))
+      senderSourceOptions.filter(({ value }) =>
+        sender.hasSources.includes(value)
+      )
     );
     /**
      * Update `allowedReceivers` to only include the Receiver Types that a Sender is able to
@@ -259,11 +261,11 @@ function TransferWorkflow() {
    * updates. This will allow the Receiver Destination to get updated with only options that are
    * allowed for a given workflow.
    */
-  function handleReceiverChanged(reciever): void {
-    setSelectedReceiver(reciever);
+  function handleReceiverChanged(receiver): void {
+    setSelectedReceiver(receiver);
     setAllowedReceiverDestinations(
       receiverDestinationOptions.filter(({ value }) =>
-        reciever.destinations.includes(value)
+        receiver.hasDestinations.includes(value)
       )
     );
   }
@@ -408,6 +410,8 @@ function TransferWorkflow() {
       setUnsupportedFundsFlow(false);
       setWebhookJsonData(undefined);
       setAllowedSenderSources(null);
+      setAllowedReceivers(null);
+      setAllowedReceiverDestinations(null);
       setSelectedSender(null);
       setSelectedSource(null);
       setSelectedReceiver(null);


### PR DESCRIPTION
**Changelog**:
* Disable Balance as option when UCR is selected as Sender Type
* Automatically disable Receiver `<select>` elements until a Sender Type and Sender Source has been set