### PR TITLE
DEV-1494: Update existing docs to include tooltips where relevant

### DIFF
--- a/app/components/base/ContentTooltip.tsx
+++ b/app/components/base/ContentTooltip.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { type PropsWithChildren } from "react";
 import {
   styled,
   SvgIcon,
@@ -9,6 +9,7 @@ import {
   Typography,
 } from "@mui/material";
 import { PURPLE_PRIMARY, WHITE_PRIMARY } from "../colors";
+import tooltipPresets from "../tooltip-presets";
 
 const WrappedMuiTooltip = styled(({ className, ...props }: TooltipProps) => (
   <MuiTooltip {...props} classes={{ popper: className }} />
@@ -41,19 +42,37 @@ const TextWrapper = styled("div", { name: "TextWrapper" })({
   padding: "0.5rem",
 });
 
-interface Props {
-  displayText: string;
-  tooltip: {
-    content: string;
-    icon?: SvgIconProps["component"];
-    title?: string;
-  };
+export interface DefaultContentTooltipProps {
+  content: string;
+  icon?: SvgIconProps["component"];
+  title?: string;
 }
 
+export interface PresetContentTooltipProps {
+  preset: keyof (typeof tooltipPresets)["presets"];
+}
+
+export type ContentTooltipProps =
+  | DefaultContentTooltipProps
+  | PresetContentTooltipProps;
+
+const isPresetTooltip = (obj: any): obj is PresetContentTooltipProps =>
+  !!obj.preset;
+
+const getPropsFromPreset = (
+  obj: PresetContentTooltipProps
+): DefaultContentTooltipProps => ({
+  ...tooltipPresets.presets[obj.preset],
+});
+
 export default function ContentTooltip({
-  displayText,
-  tooltip: { content, icon, title },
-}: Props) {
+  children,
+  ...initialProps
+}: PropsWithChildren<ContentTooltipProps>) {
+  const { content, icon, title } = isPresetTooltip(initialProps)
+    ? getPropsFromPreset(initialProps)
+    : initialProps;
+
   return (
     <WrappedMuiTooltip
       placement="top"
@@ -61,7 +80,11 @@ export default function ContentTooltip({
         <TooltipWrapper>
           {icon && (
             <IconWrapper>
-              <SvgIcon component={icon} sx={{ color: WHITE_PRIMARY }} />
+              <SvgIcon
+                component={icon}
+                inheritViewBox
+                sx={{ color: WHITE_PRIMARY }}
+              />
             </IconWrapper>
           )}
 
@@ -79,7 +102,7 @@ export default function ContentTooltip({
         </TooltipWrapper>
       }
     >
-      <span>{displayText}</span>
+      <span>{children}</span>
     </WrappedMuiTooltip>
   );
 }

--- a/app/components/base/ContentTooltip.tsx
+++ b/app/components/base/ContentTooltip.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {
   styled,
   SvgIcon,
-  SvgIconProps,
+  type SvgIconProps,
   Tooltip as MuiTooltip,
   tooltipClasses,
   type TooltipProps,

--- a/app/components/base/ContentTooltip.tsx
+++ b/app/components/base/ContentTooltip.tsx
@@ -40,6 +40,11 @@ const IconWrapper = styled("div", { name: "IconWrapper" })({
   background: PURPLE_PRIMARY,
   display: "flex",
   padding: "0.0625rem 0.5rem",
+  "& svg": {
+    "& path": {
+      fill: `${WHITE_PRIMARY} !important`,
+    },
+  },
 });
 
 const TextWrapper = styled("div", { name: "TextWrapper" })({

--- a/app/components/base/ContentTooltip.tsx
+++ b/app/components/base/ContentTooltip.tsx
@@ -8,8 +8,10 @@ import {
   type TooltipProps,
   Typography,
 } from "@mui/material";
-import { PURPLE_PRIMARY, WHITE_PRIMARY } from "../colors";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import { ORANGE_PRIMARY, PURPLE_PRIMARY, WHITE_PRIMARY } from "../colors";
 import tooltipPresets from "../tooltip-presets";
+import { ROBOTO } from "../typography";
 
 const WrappedMuiTooltip = styled(({ className, ...props }: TooltipProps) => (
   <MuiTooltip {...props} classes={{ popper: className }} />
@@ -18,6 +20,11 @@ const WrappedMuiTooltip = styled(({ className, ...props }: TooltipProps) => (
     backgroundColor: "transparent",
   },
 }));
+
+const WrappedSpan = styled("span", { name: "WrappedSpan" })({
+  fontFamily: ROBOTO,
+  color: ORANGE_PRIMARY,
+});
 
 const TooltipWrapper = styled("div", { name: "TooltipWrapper" })({
   background: WHITE_PRIMARY,
@@ -46,6 +53,7 @@ export interface DefaultContentTooltipProps {
   content: string;
   icon?: SvgIconProps["component"];
   title?: string;
+  href?: string;
 }
 
 export interface PresetContentTooltipProps {
@@ -57,7 +65,7 @@ export interface PresetContentTooltipProps {
 export type ContentTooltipProps = (
   | DefaultContentTooltipProps
   | PresetContentTooltipProps
-) & { testSuite?: boolean };
+) & { testSuite?: boolean; href?: string };
 
 const isPresetTooltip = (obj: any): obj is PresetContentTooltipProps =>
   !!obj.preset;
@@ -71,18 +79,22 @@ const getPropsFromPreset = (
 export default function ContentTooltip({
   children,
   testSuite,
+  href,
   ...initialProps
 }: PropsWithChildren<ContentTooltipProps>) {
   const { content, icon, title } = isPresetTooltip(initialProps)
     ? getPropsFromPreset(initialProps)
     : initialProps;
 
+  // Use the "OpenInNew" icon when an href prop is provided, but a custom icon isn't provided
+  const iconComponent = href && !icon ? OpenInNewIcon : icon;
+
   const innerTooltip = (
     <TooltipWrapper>
-      {icon && (
+      {iconComponent && (
         <IconWrapper>
           <SvgIcon
-            component={icon}
+            component={iconComponent}
             inheritViewBox
             sx={{ color: WHITE_PRIMARY }}
           />
@@ -95,7 +107,6 @@ export default function ContentTooltip({
             {title}
           </Typography>
         )}
-
         <Typography variant="body2" sx={{ color: PURPLE_PRIMARY }}>
           {content}
         </Typography>
@@ -103,10 +114,25 @@ export default function ContentTooltip({
     </TooltipWrapper>
   );
 
+  // Wrap the children in an <a> tag if href is provided
+  if (href) {
+    return (
+      <a href={href}>
+        {testSuite ? (
+          innerTooltip
+        ) : (
+          <WrappedMuiTooltip placement="top" title={innerTooltip}>
+            <WrappedSpan>{children}</WrappedSpan>
+          </WrappedMuiTooltip>
+        )}
+      </a>
+    );
+  }
+
   if (testSuite) return innerTooltip;
   return (
     <WrappedMuiTooltip placement="top" title={innerTooltip}>
-      <span>{children}</span>
+      <WrappedSpan>{children}</WrappedSpan>
     </WrappedMuiTooltip>
   );
 }

--- a/app/components/base/ContentTooltip.tsx
+++ b/app/components/base/ContentTooltip.tsx
@@ -52,9 +52,12 @@ export interface PresetContentTooltipProps {
   preset: keyof (typeof tooltipPresets)["presets"];
 }
 
-export type ContentTooltipProps =
+// testSuite should be set to true for tests. This will output the raw tooltip,
+// rather than wrapping it inside a MUI component.
+export type ContentTooltipProps = (
   | DefaultContentTooltipProps
-  | PresetContentTooltipProps;
+  | PresetContentTooltipProps
+) & { testSuite?: boolean };
 
 const isPresetTooltip = (obj: any): obj is PresetContentTooltipProps =>
   !!obj.preset;
@@ -67,41 +70,42 @@ const getPropsFromPreset = (
 
 export default function ContentTooltip({
   children,
+  testSuite,
   ...initialProps
 }: PropsWithChildren<ContentTooltipProps>) {
   const { content, icon, title } = isPresetTooltip(initialProps)
     ? getPropsFromPreset(initialProps)
     : initialProps;
 
+  const innerTooltip = (
+    <TooltipWrapper>
+      {icon && (
+        <IconWrapper>
+          <SvgIcon
+            component={icon}
+            inheritViewBox
+            sx={{ color: WHITE_PRIMARY }}
+          />
+        </IconWrapper>
+      )}
+
+      <TextWrapper>
+        {title && (
+          <Typography variant="subtitle2" sx={{ color: PURPLE_PRIMARY }}>
+            {title}
+          </Typography>
+        )}
+
+        <Typography variant="body2" sx={{ color: PURPLE_PRIMARY }}>
+          {content}
+        </Typography>
+      </TextWrapper>
+    </TooltipWrapper>
+  );
+
+  if (testSuite) return innerTooltip;
   return (
-    <WrappedMuiTooltip
-      placement="top"
-      title={
-        <TooltipWrapper>
-          {icon && (
-            <IconWrapper>
-              <SvgIcon
-                component={icon}
-                inheritViewBox
-                sx={{ color: WHITE_PRIMARY }}
-              />
-            </IconWrapper>
-          )}
-
-          <TextWrapper>
-            {title && (
-              <Typography variant="subtitle2" sx={{ color: PURPLE_PRIMARY }}>
-                {title}
-              </Typography>
-            )}
-
-            <Typography variant="body2" sx={{ color: PURPLE_PRIMARY }}>
-              {content}
-            </Typography>
-          </TextWrapper>
-        </TooltipWrapper>
-      }
-    >
+    <WrappedMuiTooltip placement="top" title={innerTooltip}>
       <span>{children}</span>
     </WrappedMuiTooltip>
   );

--- a/app/components/base/ContentTooltip.tsx
+++ b/app/components/base/ContentTooltip.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import {
+  styled,
+  SvgIcon,
+  SvgIconProps,
+  Tooltip as MuiTooltip,
+  tooltipClasses,
+  type TooltipProps,
+  Typography,
+} from "@mui/material";
+import { PURPLE_PRIMARY, WHITE_PRIMARY } from "../colors";
+
+const WrappedMuiTooltip = styled(({ className, ...props }: TooltipProps) => (
+  <MuiTooltip {...props} classes={{ popper: className }} />
+))(() => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: "transparent",
+  },
+}));
+
+const TooltipWrapper = styled("div", { name: "ContentTooltip" })({
+  background: WHITE_PRIMARY,
+  border: `1px solid ${PURPLE_PRIMARY}`,
+  borderRadius: "0.25rem",
+  display: "flex",
+  width: "16.5rem",
+});
+
+const IconWrapper = styled("div", { name: "IconWrapper" })({
+  alignItems: "center",
+  alignSelf: "stretch",
+  background: PURPLE_PRIMARY,
+  display: "flex",
+  padding: "0.0625rem 0.5rem",
+});
+
+const TextWrapper = styled("div", { name: "TextWrapper" })({
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.625rem",
+  padding: "0.5rem",
+});
+
+interface Props {
+  displayText: string;
+  tooltip: {
+    content: string;
+    icon?: SvgIconProps["component"];
+    title?: string;
+  };
+}
+
+export default function ContentTooltip({
+  displayText,
+  tooltip: { content, icon, title },
+}: Props) {
+  return (
+    <WrappedMuiTooltip
+      placement="top"
+      title={
+        <TooltipWrapper>
+          {icon && (
+            <IconWrapper>
+              <SvgIcon component={icon} sx={{ color: WHITE_PRIMARY }} />
+            </IconWrapper>
+          )}
+
+          <TextWrapper>
+            {title && (
+              <Typography variant="subtitle2" sx={{ color: PURPLE_PRIMARY }}>
+                {title}
+              </Typography>
+            )}
+
+            <Typography variant="body2" sx={{ color: PURPLE_PRIMARY }}>
+              {content}
+            </Typography>
+          </TextWrapper>
+        </TooltipWrapper>
+      }
+    >
+      <span>{displayText}</span>
+    </WrappedMuiTooltip>
+  );
+}

--- a/app/components/base/ContentTooltip.tsx
+++ b/app/components/base/ContentTooltip.tsx
@@ -18,7 +18,7 @@ const WrappedMuiTooltip = styled(({ className, ...props }: TooltipProps) => (
   },
 }));
 
-const TooltipWrapper = styled("div", { name: "ContentTooltip" })({
+const TooltipWrapper = styled("div", { name: "TooltipWrapper" })({
   background: WHITE_PRIMARY,
   border: `1px solid ${PURPLE_PRIMARY}`,
   borderRadius: "0.25rem",

--- a/app/components/base/__tests__/ContentTooltip.test.tsx
+++ b/app/components/base/__tests__/ContentTooltip.test.tsx
@@ -48,6 +48,36 @@ describe("ContentTooltip", () => {
     expect(tree).toMatchSnapshot();
   });
 
+  test("with icon, with title, with href", () => {
+    const tree = renderer
+      .create(
+        <ContentTooltip
+          content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds."
+          icon={AcUnit}
+          title="The Dwolla Balance"
+          href="https://developers.dwolla.com/docs"
+        >
+          a digital wallet
+        </ContentTooltip>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test("with href, no icon", () => {
+    const tree = renderer
+      .create(
+        <ContentTooltip
+          content="When a custom icon isn't provided, the tooltip will use a default icon"
+          href="https://developers.dwolla.com/docs"
+        >
+          a digital wallet
+        </ContentTooltip>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   test("with `dwolla-balance` preset", () => {
     const tree = renderer
       .create(

--- a/app/components/base/__tests__/ContentTooltip.test.tsx
+++ b/app/components/base/__tests__/ContentTooltip.test.tsx
@@ -6,7 +6,10 @@ describe("ContentTooltip", () => {
   test("default", () => {
     const tree = renderer
       .create(
-        <ContentTooltip content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds.">
+        <ContentTooltip
+          content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds."
+          testSuite
+        >
           a digital wallet
         </ContentTooltip>
       )
@@ -20,6 +23,7 @@ describe("ContentTooltip", () => {
         <ContentTooltip
           content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds."
           icon={AcUnit}
+          testSuite
         >
           a digital wallet
         </ContentTooltip>
@@ -34,6 +38,7 @@ describe("ContentTooltip", () => {
         <ContentTooltip
           content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds."
           icon={AcUnit}
+          testSuite
           title="The Dwolla Balance"
         >
           a digital wallet
@@ -46,7 +51,9 @@ describe("ContentTooltip", () => {
   test("with `dwolla-balance` preset", () => {
     const tree = renderer
       .create(
-        <ContentTooltip preset="dwolla-balance">Dwolla Balance</ContentTooltip>
+        <ContentTooltip preset="dwolla-balance" testSuite>
+          Dwolla Balance
+        </ContentTooltip>
       )
       .toJSON();
     expect(tree).toMatchSnapshot();

--- a/app/components/base/__tests__/ContentTooltip.test.tsx
+++ b/app/components/base/__tests__/ContentTooltip.test.tsx
@@ -1,0 +1,54 @@
+import renderer from "react-test-renderer";
+import { AcUnit } from "@mui/icons-material";
+import ContentTooltip from "../ContentTooltip";
+
+describe("ContentTooltip", () => {
+  test("default", () => {
+    const tree = renderer
+      .create(
+        <ContentTooltip content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds.">
+          a digital wallet
+        </ContentTooltip>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test("with icon, without title", () => {
+    const tree = renderer
+      .create(
+        <ContentTooltip
+          content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds."
+          icon={AcUnit}
+        >
+          a digital wallet
+        </ContentTooltip>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test("with icon, with title", () => {
+    const tree = renderer
+      .create(
+        <ContentTooltip
+          content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds."
+          icon={AcUnit}
+          title="The Dwolla Balance"
+        >
+          a digital wallet
+        </ContentTooltip>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  test("with `dwolla-balance` preset", () => {
+    const tree = renderer
+      .create(
+        <ContentTooltip preset="dwolla-balance">Dwolla Balance</ContentTooltip>
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/app/components/base/__tests__/__snapshots__/ContentTooltip.test.tsx.snap
+++ b/app/components/base/__tests__/__snapshots__/ContentTooltip.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`ContentTooltip with \`dwolla-balance\` preset 1`] = `
   className="css-14hvf8r-TooltipWrapper-root"
 >
   <div
-    className="css-1isforb-IconWrapper-root"
+    className="css-1cmw82f-IconWrapper-root"
   >
     <svg
       aria-hidden={true}
@@ -72,7 +72,7 @@ exports[`ContentTooltip with icon, with title 1`] = `
   className="css-14hvf8r-TooltipWrapper-root"
 >
   <div
-    className="css-1isforb-IconWrapper-root"
+    className="css-1cmw82f-IconWrapper-root"
   >
     <svg
       aria-hidden={true}
@@ -129,7 +129,7 @@ exports[`ContentTooltip with icon, without title 1`] = `
   className="css-14hvf8r-TooltipWrapper-root"
 >
   <div
-    className="css-1isforb-IconWrapper-root"
+    className="css-1cmw82f-IconWrapper-root"
   >
     <svg
       aria-hidden={true}

--- a/app/components/base/__tests__/__snapshots__/ContentTooltip.test.tsx.snap
+++ b/app/components/base/__tests__/__snapshots__/ContentTooltip.test.tsx.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContentTooltip default 1`] = `
+<span
+  aria-label={null}
+  aria-labelledby={null}
+  className=""
+  data-mui-internal-clone-element={true}
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseLeave={[Function]}
+  onMouseOver={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+>
+  a digital wallet
+</span>
+`;
+
+exports[`ContentTooltip with \`dwolla-balance\` preset 1`] = `
+<span
+  aria-label={null}
+  aria-labelledby={null}
+  className=""
+  data-mui-internal-clone-element={true}
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseLeave={[Function]}
+  onMouseOver={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+>
+  Dwolla Balance
+</span>
+`;
+
+exports[`ContentTooltip with icon, with title 1`] = `
+<span
+  aria-label={null}
+  aria-labelledby={null}
+  className=""
+  data-mui-internal-clone-element={true}
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseLeave={[Function]}
+  onMouseOver={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+>
+  a digital wallet
+</span>
+`;
+
+exports[`ContentTooltip with icon, without title 1`] = `
+<span
+  aria-label={null}
+  aria-labelledby={null}
+  className=""
+  data-mui-internal-clone-element={true}
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseLeave={[Function]}
+  onMouseOver={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+>
+  a digital wallet
+</span>
+`;

--- a/app/components/base/__tests__/__snapshots__/ContentTooltip.test.tsx.snap
+++ b/app/components/base/__tests__/__snapshots__/ContentTooltip.test.tsx.snap
@@ -46,6 +46,27 @@ exports[`ContentTooltip with \`dwolla-balance\` preset 1`] = `
 </div>
 `;
 
+exports[`ContentTooltip with href, no icon 1`] = `
+<a
+  href="https://developers.dwolla.com/docs"
+>
+  <span
+    aria-label={null}
+    aria-labelledby={null}
+    className=" css-1mz5jyq-WrappedSpan-root"
+    data-mui-internal-clone-element={true}
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseLeave={[Function]}
+    onMouseOver={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+  >
+    a digital wallet
+  </span>
+</a>
+`;
+
 exports[`ContentTooltip with icon, with title 1`] = `
 <div
   className="css-14hvf8r-TooltipWrapper-root"
@@ -80,6 +101,27 @@ exports[`ContentTooltip with icon, with title 1`] = `
     </p>
   </div>
 </div>
+`;
+
+exports[`ContentTooltip with icon, with title, with href 1`] = `
+<a
+  href="https://developers.dwolla.com/docs"
+>
+  <span
+    aria-label={null}
+    aria-labelledby={null}
+    className=" css-1mz5jyq-WrappedSpan-root"
+    data-mui-internal-clone-element={true}
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseLeave={[Function]}
+    onMouseOver={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+  >
+    a digital wallet
+  </span>
+</a>
 `;
 
 exports[`ContentTooltip with icon, without title 1`] = `

--- a/app/components/base/__tests__/__snapshots__/ContentTooltip.test.tsx.snap
+++ b/app/components/base/__tests__/__snapshots__/ContentTooltip.test.tsx.snap
@@ -1,69 +1,114 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ContentTooltip default 1`] = `
-<span
-  aria-label={null}
-  aria-labelledby={null}
-  className=""
-  data-mui-internal-clone-element={true}
-  onBlur={[Function]}
-  onFocus={[Function]}
-  onMouseLeave={[Function]}
-  onMouseOver={[Function]}
-  onTouchEnd={[Function]}
-  onTouchStart={[Function]}
+<div
+  className="css-14hvf8r-TooltipWrapper-root"
 >
-  a digital wallet
-</span>
+  <div
+    className="css-qzjlos-TextWrapper-root"
+  >
+    <p
+      className="MuiTypography-root MuiTypography-body2 css-1b3ysuv-MuiTypography-root"
+    >
+      The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds.
+    </p>
+  </div>
+</div>
 `;
 
 exports[`ContentTooltip with \`dwolla-balance\` preset 1`] = `
-<span
-  aria-label={null}
-  aria-labelledby={null}
-  className=""
-  data-mui-internal-clone-element={true}
-  onBlur={[Function]}
-  onFocus={[Function]}
-  onMouseLeave={[Function]}
-  onMouseOver={[Function]}
-  onTouchEnd={[Function]}
-  onTouchStart={[Function]}
+<div
+  className="css-14hvf8r-TooltipWrapper-root"
 >
-  Dwolla Balance
-</span>
+  <div
+    className="css-1isforb-IconWrapper-root"
+  >
+    <svg
+      aria-hidden={true}
+      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6lijc5-MuiSvgIcon-root"
+      focusable="false"
+    />
+  </div>
+  <div
+    className="css-qzjlos-TextWrapper-root"
+  >
+    <h6
+      className="MuiTypography-root MuiTypography-subtitle2 css-81nu7f-MuiTypography-root"
+    >
+      Dwolla Balance
+    </h6>
+    <p
+      className="MuiTypography-root MuiTypography-body2 css-1b3ysuv-MuiTypography-root"
+    >
+      Dwolla Balance is a digital wallet-based solution that lets you and your users hold funds and initiate payments.
+    </p>
+  </div>
+</div>
 `;
 
 exports[`ContentTooltip with icon, with title 1`] = `
-<span
-  aria-label={null}
-  aria-labelledby={null}
-  className=""
-  data-mui-internal-clone-element={true}
-  onBlur={[Function]}
-  onFocus={[Function]}
-  onMouseLeave={[Function]}
-  onMouseOver={[Function]}
-  onTouchEnd={[Function]}
-  onTouchStart={[Function]}
+<div
+  className="css-14hvf8r-TooltipWrapper-root"
 >
-  a digital wallet
-</span>
+  <div
+    className="css-1isforb-IconWrapper-root"
+  >
+    <svg
+      aria-hidden={true}
+      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1rysupe-MuiSvgIcon-root-MuiSvgIcon-root"
+      data-testid="AcUnitIcon"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M22 11h-4.17l3.24-3.24-1.41-1.42L15 11h-2V9l4.66-4.66-1.42-1.41L13 6.17V2h-2v4.17L7.76 2.93 6.34 4.34 11 9v2H9L4.34 6.34 2.93 7.76 6.17 11H2v2h4.17l-3.24 3.24 1.41 1.42L9 13h2v2l-4.66 4.66 1.42 1.41L11 17.83V22h2v-4.17l3.24 3.24 1.42-1.41L13 15v-2h2l4.66 4.66 1.41-1.42L17.83 13H22z"
+      />
+    </svg>
+  </div>
+  <div
+    className="css-qzjlos-TextWrapper-root"
+  >
+    <h6
+      className="MuiTypography-root MuiTypography-subtitle2 css-81nu7f-MuiTypography-root"
+    >
+      The Dwolla Balance
+    </h6>
+    <p
+      className="MuiTypography-root MuiTypography-body2 css-1b3ysuv-MuiTypography-root"
+    >
+      The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds.
+    </p>
+  </div>
+</div>
 `;
 
 exports[`ContentTooltip with icon, without title 1`] = `
-<span
-  aria-label={null}
-  aria-labelledby={null}
-  className=""
-  data-mui-internal-clone-element={true}
-  onBlur={[Function]}
-  onFocus={[Function]}
-  onMouseLeave={[Function]}
-  onMouseOver={[Function]}
-  onTouchEnd={[Function]}
-  onTouchStart={[Function]}
+<div
+  className="css-14hvf8r-TooltipWrapper-root"
 >
-  a digital wallet
-</span>
+  <div
+    className="css-1isforb-IconWrapper-root"
+  >
+    <svg
+      aria-hidden={true}
+      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1rysupe-MuiSvgIcon-root-MuiSvgIcon-root"
+      data-testid="AcUnitIcon"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M22 11h-4.17l3.24-3.24-1.41-1.42L15 11h-2V9l4.66-4.66-1.42-1.41L13 6.17V2h-2v4.17L7.76 2.93 6.34 4.34 11 9v2H9L4.34 6.34 2.93 7.76 6.17 11H2v2h4.17l-3.24 3.24 1.41 1.42L9 13h2v2l-4.66 4.66 1.42 1.41L11 17.83V22h2v-4.17l3.24 3.24 1.42-1.41L13 15v-2h2l4.66 4.66 1.41-1.42L17.83 13H22z"
+      />
+    </svg>
+  </div>
+  <div
+    className="css-qzjlos-TextWrapper-root"
+  >
+    <p
+      className="MuiTypography-root MuiTypography-body2 css-1b3ysuv-MuiTypography-root"
+    >
+      The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds.
+    </p>
+  </div>
+</div>
 `;

--- a/app/components/tooltip-presets.ts
+++ b/app/components/tooltip-presets.ts
@@ -1,4 +1,6 @@
 import { ReactComponent as DwollaBalanceIcon } from "../../assets/images/product-icons-and-heroes/dwolla-balance-icon-white-48x48.svg";
+import { ReactComponent as DwollaConnectIcon } from "../../assets/images/product-icons-and-heroes/dwolla-connect-icon-white-48x48.svg";
+import { ReactComponent as SandboxIcon } from "../../assets/images/component-icons/side-nav/testing-sandbox.svg";
 
 export default {
   presets: {
@@ -7,6 +9,48 @@ export default {
         "Dwolla Balance is a digital wallet-based solution that lets you and your users hold funds and initiate payments.",
       icon: DwollaBalanceIcon,
       title: "Dwolla Balance",
+    },
+    "dwolla-connect": {
+      content:
+        "Dwolla Connect leverages your existing banking relationships and corresponding commercial bank accounts to integrate modern payment processing capabilities into your operations.",
+      icon: DwollaConnectIcon,
+      title: "Dwolla Connect",
+    },
+    "external-party": {
+      content:
+        "A type of Dwolla account, either business or personal, that identifies your end-users. An External Party is required in order to initiate a transfer to a customer’s bank account.",
+      title: "External Party",
+    },
+    "funding-source": {
+      content:
+        "A linked bank account that can be used to route funds to a Dwolla Account or External Party, denoted by the use of an account and routing number, most often connected to a checking or savings account.",
+      title: "Funding Source",
+    },
+    "idempotency-key": {
+      content:
+        "Use a unique key in the API request header to prevent duplicate operations in Dwolla.",
+      title: "Idempotency key",
+    },
+    "openapi-spec": {
+      content:
+        "A standardized interface description for HTTP/REST APIs, facilitating understanding without source code access. Can be combined with additional tooling, such as generating documentation, a Postman collection, or a Software Development Kit.",
+      title: "Open API Specification",
+    },
+    sandbox: {
+      content:
+        "A simulation of Dwolla's production environment, complete with all API endpoints, but without real banking or user data.",
+      icon: SandboxIcon,
+      title: "Sandbox",
+    },
+    "secure-exchange": {
+      content:
+        "A secure data-sharing channel between your Dwolla account and Dwolla's ecosystem partners, enabling controlled access, such as connecting a verified bank account, without sensitive data storage.",
+      title: "Secure Exchange",
+    },
+    "treasury-account": {
+      content:
+        " An identifiable “connection” between Dwolla and a supported Treasury Partner, identified by your ACH Company ID or Gateway Company ID, depending on the banking institution.",
+      title: "Treasury Account",
     },
   },
 } as const;

--- a/app/components/tooltip-presets.ts
+++ b/app/components/tooltip-presets.ts
@@ -18,12 +18,12 @@ export default {
     },
     "external-party": {
       content:
-        "A type of Dwolla account, either business or personal, that identifies your end-users. An External Party is required in order to initiate a transfer to a customer’s bank account.",
+        "A type of end-user, either business or personal, that identifies the owner of the underlying bank account used in an account-to-account payment. An External Party is required in order to initiate a transfer to or from a user's bank account.",
       title: "External Party",
     },
     "funding-source": {
       content:
-        "A linked bank account that can be used to route funds to a Dwolla Account or External Party, denoted by the use of an account and routing number, most often connected to a checking or savings account.",
+        "A linked bank account that allows you to send and receive account-to-account payments with another party. It is identified by a unique account and routing number, and is typically associated with a checking or savings account.",
       title: "Funding Source",
     },
     "idempotency-key": {
@@ -38,13 +38,13 @@ export default {
     },
     sandbox: {
       content:
-        "A simulation of Dwolla's production environment, complete with all API endpoints, but without real banking or user data.",
+        "A simulated environment where you can imitate production/“live” use cases, safely test your API requests and responses in a controlled setting, and mock out low-volume and high volume data.",
       icon: SandboxIcon,
       title: "Sandbox",
     },
     "secure-exchange": {
       content:
-        "A secure data-sharing channel between your Dwolla account and Dwolla's ecosystem partners, enabling controlled access, such as connecting a verified bank account, without sensitive data storage.",
+        "A secure data exchange that connects Dwolla to trusted Open Finance ecosystem partners, enabling tokenized access to services such as bank account ownership verification.",
       title: "Secure Exchange",
     },
     "treasury-account": {
@@ -54,7 +54,7 @@ export default {
     },
     webhook: {
       content:
-        "An HTTP request sent to a specified URL for real-time updates and notifications when specific events or data changes occur in your platform.",
+        "An HTTP request sent to a specified URL for near real-time updates and notifications when specific events or data changes occur in the Dwolla platform.",
       title: "Webhook",
     },
   },

--- a/app/components/tooltip-presets.ts
+++ b/app/components/tooltip-presets.ts
@@ -1,0 +1,12 @@
+import { ReactComponent as DwollaBalanceIcon } from "../../assets/images/product-icons-and-heroes/dwolla-balance-icon-white-48x48.svg";
+
+export default {
+  presets: {
+    "dwolla-balance": {
+      content:
+        "Dwolla Balance is a digital wallet-based solution that lets you and your users hold funds and initiate payments.",
+      icon: DwollaBalanceIcon,
+      title: "Dwolla Balance",
+    },
+  },
+} as const;

--- a/app/components/tooltip-presets.ts
+++ b/app/components/tooltip-presets.ts
@@ -49,8 +49,13 @@ export default {
     },
     "treasury-account": {
       content:
-        " An identifiable “connection” between Dwolla and a supported Treasury Partner, identified by your ACH Company ID or Gateway Company ID, depending on the banking institution.",
+        "An identifiable “connection” between Dwolla and a supported Treasury Partner, identified by your ACH Company ID or Gateway Company ID, depending on the banking institution.",
       title: "Treasury Account",
+    },
+    webhook: {
+      content:
+        "An HTTP request sent to a specified URL for real-time updates and notifications when specific events or data changes occur in your platform.",
+      title: "Webhook",
     },
   },
 } as const;

--- a/assets/api-resource-tables/accounts/CreateFundingSource.tsx
+++ b/assets/api-resource-tables/accounts/CreateFundingSource.tsx
@@ -1,6 +1,7 @@
 import { type TableContents } from "../../../app/components/base/material-ui/Table";
 import HalLink from "../HalLink";
 import { Link } from "../../../app/components/base/Typography";
+import ContentTooltip from "../../../app/components/base/ContentTooltip";
 
 export default {
   headers: ["Property", "Required", "Type", "Description"],
@@ -22,7 +23,11 @@ export default {
         rows: [
           [
             [
-              "treasury-account",
+              <span>
+                <ContentTooltip preset="treasury-account">
+                  treasury-account
+                </ContentTooltip>
+              </span>,
               <span>
                 References the Treasury Account resource in relation to which
                 the funding source is created.

--- a/layouts/index.tsx
+++ b/layouts/index.tsx
@@ -15,6 +15,7 @@ import CodeExamples, {
   CodeExample,
 } from "../app/components/partial/code/CodeExamples";
 import Collapsible from "../app/components/base/Collapsible";
+import ContentTooltip from "../app/components/base/ContentTooltip";
 import ExternalCTA from "../app/components/base/ExternalCTA";
 import FooterCTA from "../app/components/base/FooterCTA";
 import Image from "../app/components/base/Image";
@@ -56,6 +57,7 @@ const MDX_COMPONENTS = {
   CodeExample,
   CodeExamples,
   Collapsible,
+  ContentTooltip,
   ExternalCTA,
   FooterCTA,
   Image,

--- a/pages/api-reference/authorization/index.mdx
+++ b/pages/api-reference/authorization/index.mdx
@@ -20,7 +20,7 @@ Dwolla utilizes the [OAuth 2 protocol](https://oauth.net/2/) to facilitate autho
 
 #### Creating an application
 
-Before you can get started with making OAuth requests, you’ll need to first register an application with Dwolla by logging in and navigating to the applications page. Once an application is registered you will obtain your `client_id` and `client_secret` (aka App Key and Secret), which will be used to identify your application when calling the Dwolla API. The Sandbox environment provides you with a created application once you have signed up for an account. Learn more in our [getting started guide](https://developers.dwolla.com/guides/sandbox). **Remember:** Your client_secret should be kept a secret! Be sure to store your client credentials securely.
+Before you can get started with making OAuth requests, you’ll need to first register an application with Dwolla by logging in and navigating to the applications page. Once an application is registered you will obtain your `client_id` and `client_secret` (aka App Key and Secret), which will be used to identify your application when calling the Dwolla API. The <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> environment provides you with a created application once you have signed up for an account. Learn more in our [getting started guide](https://developers.dwolla.com/guides/sandbox). **Remember:** Your client_secret should be kept a secret! Be sure to store your client credentials securely.
 
 <InlineCTA
   icon={guideIcon}

--- a/pages/api-reference/connect/exchanges/create-exchange-for-an-external-party.mdx
+++ b/pages/api-reference/connect/exchanges/create-exchange-for-an-external-party.mdx
@@ -11,7 +11,7 @@ meta:
 
 # Create an exchange for an external party
 
-This section contains information on how to create an exchange for an exernal party. The creation of an exchange serves as the “hand-shake” between Dwolla and a trusted ecosystem partner. The creation of an exchange requires a `_link` to the exchange partner and tokenized data which encapsulates limited permissioned access between an ecosystem partner and Dwolla.
+This section contains information on how to create an exchange for an <span><ContentTooltip preset="external-party">external party</ContentTooltip></span>. The creation of an exchange serves as the “hand-shake” between Dwolla and a trusted ecosystem partner. The creation of an exchange requires a `_link` to the exchange partner and tokenized data which encapsulates limited permissioned access between an ecosystem partner and Dwolla.
 
 ### HTTP request
 

--- a/pages/api-reference/connect/exchanges/list-exchanges-for-an-external-party.mdx
+++ b/pages/api-reference/connect/exchanges/list-exchanges-for-an-external-party.mdx
@@ -11,7 +11,7 @@ meta:
 
 # List exchanges for an external party
 
-This section contains information on how to retrieve the list of exchanges associated with an External Party resource.
+This section contains information on how to retrieve the list of exchanges associated with an <span><ContentTooltip preset="external-party">External Party</ContentTooltip></span> resource.
 
 ### HTTP request
 

--- a/pages/api-reference/connect/external-parties/create.mdx
+++ b/pages/api-reference/connect/external-parties/create.mdx
@@ -11,7 +11,7 @@ meta:
 
 # Create an External Party
 
-External Parties are Dwolla resources that exist underneath a Connect account. To create an External Party, Dwolla will require a small subset of information to act as an identifier.
+External Parties are Dwolla resources that exist underneath a Connect account. To create an <span> <ContentTooltip preset="external-party">External Parties</ContentTooltip></span>, Dwolla will require a small subset of information to act as an identifier.
 
 ## HTTP request
 

--- a/pages/api-reference/connect/external-parties/index.mdx
+++ b/pages/api-reference/connect/external-parties/index.mdx
@@ -17,7 +17,7 @@ import PersonalExternalParty from "../../../../assets/api-resource-tables/extern
 
 # External Party
 
-An `External Party` represents an individual or business that utilizes your application to send or receive transfers.
+An <span><ContentTooltip preset="external-party">External Party</ContentTooltip></span> represents an individual or business that utilizes your application to send or receive transfers.
 
 ## Resource Overview - Personal External Party
 

--- a/pages/api-reference/connect/external-parties/list-and-search.mdx
+++ b/pages/api-reference/connect/external-parties/list-and-search.mdx
@@ -11,7 +11,7 @@ meta:
 
 # List external-parties
 
-This section describes how to retrieve a list of all external parties connected to the main Dwolla Connect Account. The external parties are sorted by the `created` timestamp, with the most recent external party at the beginning of the list. The list is returned in an `_embedded` list called `external-parties`.
+This section describes how to retrieve a list of all <span><ContentTooltip preset="external-party">external parties</ContentTooltip></span> connected to the main Dwolla Connect Account. The external parties are sorted by the `created` timestamp, with the most recent external party at the beginning of the list. The list is returned in an `_embedded` list called `external-parties`.
 
 ### Pagination
 

--- a/pages/api-reference/connect/external-parties/retrieve.mdx
+++ b/pages/api-reference/connect/external-parties/retrieve.mdx
@@ -11,7 +11,7 @@ meta:
 
 # Retrieve an External Party
 
-This section shows you how to retrieve an external party resource belonging to the authorized Dwolla Account.
+This section shows you how to retrieve an <span><ContentTooltip preset="external-party">external party</ContentTooltip></span> resource belonging to the authorized Dwolla Account.
 
 ## HTTP request
 

--- a/pages/api-reference/connect/funding-sources/create-for-account.mdx
+++ b/pages/api-reference/connect/funding-sources/create-for-account.mdx
@@ -15,7 +15,7 @@ import CreateFundingSource from "../../../../assets/api-resource-tables/accounts
 
 This section details how to add a bank account to the main Dwolla Account.
 
-To add a bank account as a Funding Source, you provide the account number and a routing number along with the Treasury Account in relation to which you want to attach the bank. Typically, a bank account that you add to the main Dwolla Account will have a status of “unverified”. In order to transfer money from your bank, you will need to [verify ownership of the account](/docs/balance/micro-deposit-verification).
+To add a bank account as a Funding Source, you provide the account number and a routing number along with the <span><ContentTooltip preset="treasury-account">Treasury Account</ContentTooltip></span> in relation to which you want to attach the bank. Typically, a bank account that you add to the main Dwolla Account will have a status of “unverified”. In order to transfer money from your bank, you will need to [verify ownership of the account](/docs/balance/micro-deposit-verification).
 
 ## HTTP request
 

--- a/pages/api-reference/connect/funding-sources/create-for-external-party.mdx
+++ b/pages/api-reference/connect/funding-sources/create-for-external-party.mdx
@@ -11,7 +11,7 @@ meta:
 
 # Create a Funding Source for an External Party
 
-This section outlines how to create a funding source an External Party via the API.
+This section outlines how to create a funding source an <span><ContentTooltip preset="external-party">External Party</ContentTooltip></span> via the API.
 
 ## HTTP request
 

--- a/pages/api-reference/connect/funding-sources/index.mdx
+++ b/pages/api-reference/connect/funding-sources/index.mdx
@@ -16,7 +16,7 @@ import AccountFundingSource from "../../../../assets/api-resource-tables/account
 
 # Funding Sources
 
-The Funding Sources resource represents payment accounts that can be used to send and/or receive funds. Funding sources are relational to either the main [Dwolla Account](/api-reference/connect/funding-sources/create) or an [External Party](/api-reference/connect/external-parties/create-funding-source) and can be used to reference details on a payment account.
+The Funding Sources resource represents payment accounts that can be used to send and/or receive funds. Funding sources are relational to either the main [Dwolla Account](/api-reference/connect/funding-sources/create) or an <span><ContentTooltip preset="external-party" href="https://developers.dwolla.com/api-reference/connect/funding-sources/create-for-external-party">External Party</ContentTooltip></span> and can be used to reference details on a payment account.
 
 ### Bank Account Types
 

--- a/pages/api-reference/connect/funding-sources/list-for-account.mdx
+++ b/pages/api-reference/connect/funding-sources/list-for-account.mdx
@@ -17,7 +17,7 @@ Retrieve a list of funding sources that belong to an Account. By default, all fu
 
 All listing endpoints support cursor-based pagination to traverse through an existing data set. With cursor-based pagination you must always start at the beginning of a list and query your way forward in the data set. Cursor-based endpoints accept the `limit` and `cursor` query string parameters.
 
-A `limit` is set to control the number of objects that are returned in the response. By default, a `limit` is set to 25 objects that are returned and sorted by `created` timestamp. Limit can have a max value of 200 external party objects. The `cursor` is a pointer indicating the next item in the data set. The cursor to use for the next page of results is returned in the `_links` object where a URL is generated and returned for the `next` data set (referenced below). If you omit the `cursor` from your request, you will receive the first page of results.
+A `limit` is set to control the number of objects that are returned in the response. By default, a `limit` is set to 25 objects that are returned and sorted by `created` timestamp. Limit can have a max value of 200 objects. The `cursor` is a pointer indicating the next item in the data set. The cursor to use for the next page of results is returned in the `_links` object where a URL is generated and returned for the `next` data set (referenced below). If you omit the `cursor` from your request, you will receive the first page of results.ß
 
 It is recommended to use the `_links` object in the response which includes the following relational links for paging.
 

--- a/pages/api-reference/connect/funding-sources/list-for-external-party.mdx
+++ b/pages/api-reference/connect/funding-sources/list-for-external-party.mdx
@@ -11,13 +11,13 @@ meta:
 
 # List funding-sources for an External Party
 
-Retrieve a list of funding sources that belong to a external party. By default, all funding sources are returned unless the removed query string parameter is set to false in the request.
+Retrieve a list of funding sources that belong to a <span><ContentTooltip preset="external-party">external party</ContentTooltip></span>. By default, all funding sources are returned unless the removed query string parameter is set to false in the request.
 
 ### Pagination
 
 All listing endpoints support cursor-based pagination to traverse through an existing data set. With cursor-based pagination you must always start at the beginning of a list and query your way forward in the data set. Cursor-based endpoints accept the `limit` and `cursor` query string parameters.
 
-A `limit` is set to control the number of objects that are returned in the response. By default, a `limit` is set to 25 objects that are returned and sorted by `created` timestamp. Limit can have a max value of 200 external party objects. The `cursor` is a pointer indicating the next item in the data set. The cursor to use for the next page of results is returned in the `_links` object where a URL is generated and returned for the `next` data set (referenced below). If you omit the `cursor` from your request, you will receive the first page of results.
+A `limit` is set to control the number of objects that are returned in the response. By default, a `limit` is set to 25 objects that are returned and sorted by `created` timestamp. Limit can have a max value of 200 objects. The `cursor` is a pointer indicating the next item in the data set. The cursor to use for the next page of results is returned in the `_links` object where a URL is generated and returned for the `next` data set (referenced below). If you omit the `cursor` from your request, you will receive the first page of results.
 
 It is recommended to use the `_links` object in the response which includes the following relational links for paging.
 

--- a/pages/api-reference/connect/transfers/index.mdx
+++ b/pages/api-reference/connect/transfers/index.mdx
@@ -16,7 +16,7 @@ import Transfer from "../../../../assets/api-resource-tables/transfers/Transfer"
 
 # Transfers
 
-A transfer represents money being transferred from a `source` to a `destination`. Transfers can be created over the ACH network or over Wire. A Debit represents funds being debited from an external party's funding source. A Credit represents funds being credited to an external party's funding source.
+A transfer represents money being transferred from a `source` to a `destination`. Transfers can be created over the ACH network or over Wire. A Debit represents funds being debited from an <span><ContentTooltip preset="external-party">external party</ContentTooltip></span>'s funding source. A Credit represents funds being credited to an external party's funding source.
 
 ## Resource Overview
 

--- a/pages/api-reference/connect/transfers/initiate.mdx
+++ b/pages/api-reference/connect/transfers/initiate.mdx
@@ -17,7 +17,7 @@ This section details how to initiate a transfer between your main Dwolla Account
 
 ### Prevent duplicate transfers with idempotency key
 
-To prevent an operation from being performed more than once, Dwolla supports passing in an `Idempotency-Key` header with a unique key as the value. Multiple `POSTs` with the same idempotency key won't result in multiple resources being created.
+To prevent an operation from being performed more than once, Dwolla supports passing in an <span><ContentTooltip preset="idempotency-key">Idempotency Key</ContentTooltip></span> header with a unique key as the value. Multiple `POSTs` with the same idempotency key won't result in multiple resources being created.
 
 For example, if a request to initiate a transfer fails due to a network connection issue, you can reattempt the request with the same idempotency key to ensure that only a single transfer is created.
 
@@ -25,12 +25,12 @@ Refer to our [idempotency key](https://developers.dwolla.com/api-reference#idemp
 
 ### Simulate transfer statuses in Sandbox
 
-The Sandbox environment does not replicate any bank transfer processes, so a pending transfer will not clear or fail automatically after a few business days as it would in production.
+The <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> environment does not replicate any bank transfer processes, so a pending transfer will not clear or fail automatically after a few business days as it would in production.
 The transfer will simply remain in the pending state indefinitely. In the Sandbox environment, transfer statuses can be simulated by passing in a sentinel value in the `amount` field as referenced in the table below.
 
 | amount | Desired Transfer Status | Description                                                                                                                                 |
 | ------ | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1.01   | created                 | Triggers `account.transfer:created` event as the transfer is placed in a `created` status.                                                              |
+| 1.01   | created                 | Triggers `account.transfer:created` event as the transfer is placed in a `created` status.                                                  |
 | 1.02   | pending                 | Triggers `account.transfer:created` and `account.transfer:pending` events as the transfer updates from a `created` to `pending` status.     |
 | 2.01   | processed               | Triggers `account.transfer:created` and `account.transfer:processed` events as the transfer updates from a `created` to `processed` status. |
 | 9.99   | failed                  | Triggers `account.transfer:created` and `account.transfer:failed` events as the transfer updates from a `created` to `failed` status.       |

--- a/pages/api-reference/connect/transfers/list-and-search-for-account.mdx
+++ b/pages/api-reference/connect/transfers/list-and-search-for-account.mdx
@@ -17,7 +17,7 @@ This section covers how to retrieve an Account's list of transfers.
 
 All listing endpoints support cursor-based pagination to traverse through an existing data set. With cursor-based pagination you must always start at the beginning of a list and query your way forward in the data set. Cursor-based endpoints accept the `limit` and `cursor` query string parameters.
 
-A `limit` is set to control the number of objects that are returned in the response. By default, a `limit` is set to 25 objects that are returned and sorted by `created` timestamp. Limit can have a max value of 200 external party objects. The `cursor` is a pointer indicating the next item in the data set. The cursor to use for the next page of results is returned in the `_links` object where a URL is generated and returned for the `next` data set (referenced below). If you omit the `cursor` from your request, you will receive the first page of results.
+A `limit` is set to control the number of objects that are returned in the response. By default, a `limit` is set to 25 objects that are returned and sorted by `created` timestamp. Limit can have a max value of 200 objects. The `cursor` is a pointer indicating the next item in the data set. The cursor to use for the next page of results is returned in the `_links` object where a URL is generated and returned for the `next` data set (referenced below). If you omit the `cursor` from your request, you will receive the first page of results.
 
 It is recommended to use the `_links` object in the response which includes the following relational links for paging.
 

--- a/pages/api-reference/connect/transfers/list-and-search-for-external-party.mdx
+++ b/pages/api-reference/connect/transfers/list-and-search-for-external-party.mdx
@@ -11,13 +11,13 @@ meta:
 
 # List and search transfers for an external party
 
-This section covers how to retrieve an External Party's list of transfers.
+This section covers how to retrieve an <span><ContentTooltip preset="external-party">External Party</ContentTooltip></span>'s list of transfers.
 
 ### Pagination
 
 All listing endpoints support cursor-based pagination to traverse through an existing data set. With cursor-based pagination you must always start at the beginning of a list and query your way forward in the data set. Cursor-based endpoints accept the `limit` and `cursor` query string parameters.
 
-A `limit` is set to control the number of objects that are returned in the response. By default, a `limit` is set to 25 objects that are returned and sorted by `created` timestamp. Limit can have a max value of 200 external party objects. The `cursor` is a pointer indicating the next item in the data set. The cursor to use for the next page of results is returned in the `_links` object where a URL is generated and returned for the `next` data set (referenced below). If you omit the `cursor` from your request, you will receive the first page of results.
+A `limit` is set to control the number of objects that are returned in the response. By default, a `limit` is set to 25 objects that are returned and sorted by `created` timestamp. Limit can have a max value of 200 objects. The `cursor` is a pointer indicating the next item in the data set. The cursor to use for the next page of results is returned in the `_links` object where a URL is generated and returned for the `next` data set (referenced below). If you omit the `cursor` from your request, you will receive the first page of results.
 
 It is recommended to use the `_links` object in the response which includes the following relational links for paging.
 

--- a/pages/api-reference/connect/webhook-subscriptions/list-webhooks.mdx
+++ b/pages/api-reference/connect/webhook-subscriptions/list-webhooks.mdx
@@ -17,7 +17,7 @@ This section covers how to view all fired [webhooks](/api-reference/connect/webh
 
 All listing endpoints support cursor-based pagination to traverse through an existing data set. With cursor-based pagination you must always start at the beginning of a list and query your way forward in the data set. Cursor-based endpoints accept the `limit` and `cursor` query string parameters.
 
-A `limit` is set to control the number of objects that are returned in the response. By default, a `limit` is set to 25 objects that are returned and sorted by `created` timestamp. Limit can have a max value of 200 external party objects. The `cursor` is a pointer indicating the next item in the data set. The cursor to use for the next page of results is returned in the `_links` object where a URL is generated and returned for the `next` data set (referenced below). If you omit the `cursor` from your request, you will receive the first page of results.
+A `limit` is set to control the number of objects that are returned in the response. By default, a `limit` is set to 25 objects that are returned and sorted by `created` timestamp. Limit can have a max value of 200 objects. The `cursor` is a pointer indicating the next item in the data set. The cursor to use for the next page of results is returned in the `_links` object where a URL is generated and returned for the `next` data set (referenced below). If you omit the `cursor` from your request, you will receive the first page of results.
 
 It is recommended to use the `_links` object in the response which includes the following relational links for paging.
 

--- a/pages/api-reference/events/index.mdx
+++ b/pages/api-reference/events/index.mdx
@@ -14,7 +14,7 @@ meta:
 
 # Events
 
-When the state of a resource changes, Dwolla creates a new event resource to record the change. When an Event is created, a [Webhook](https://developers.dwolla.com/api-reference/webhooks) will be created to deliver the Event to any URLs specified by your active [Webhook Subscriptions](https://developers.dwolla.com/api-reference/webhook-subscriptions). To view example payloads for Customer related events, refer to the [Webhooks Events](https://developers.dwolla.com/concepts/webhook-events) resource within the Developer Docs.
+When the state of a resource changes, Dwolla creates a new event resource to record the change. When an Event is created, a <span><ContentTooltip preset="webhook" href="https://developers.dwolla.com/api-reference/webhooks">Webhook</ContentTooltip></span> will be created to deliver the Event to any URLs specified by your active [Webhook Subscriptions](https://developers.dwolla.com/api-reference/webhook-subscriptions). To view example payloads for Customer related events, refer to the [Webhooks Events](https://developers.dwolla.com/concepts/webhook-events) resource within the Developer Docs.
 
 ### Events resource
 

--- a/pages/api-reference/index.mdx
+++ b/pages/api-reference/index.mdx
@@ -303,7 +303,7 @@ The `path` field is a JSON pointer to the specific field in the request that has
 
 Relationships and available actions for a resource are represented with links. All resources have a `_links` attribute. At a minimum, all resources will have a `self` link which indicates the URL of the resource itself.
 
-Some links, such as `funding-sources`, give you a URL which you can follow to access related resources. For example, the customer resource has a `funding-sources` link which, when followed, will list the customer's available funding sources.
+Some links, such as `funding-sources`, give you a URL which you can follow to access related resources. For example, the customer resource has a `funding-sources` link which, when followed, will list the customer's available <span><ContentTooltip preset="funding-source">funding sources</ContentTooltip></span>.
 
 Responses which contain a collection of resources have pagination links, `first`, `next`, `last`, and `prev`.
 

--- a/pages/api-reference/mass-payments/initiate.mdx
+++ b/pages/api-reference/mass-payments/initiate.mdx
@@ -14,7 +14,7 @@ This section covers how to initiate a mass payment from your Dwolla Master [Acco
 
 ### Prevent duplicate mass payment with idempotency key
 
-To prevent an operation from being performed more than once, Dwolla supports passing in an `Idempotency-Key` header with a unique key as the value. Multiple `POSTs` with the same idempotency key won't result in multiple resources being created.
+To prevent an operation from being performed more than once, Dwolla supports passing in an <span><ContentTooltip preset="idempotency-key">Idempotency Key</ContentTooltip></span> header with a unique key as the value. Multiple `POSTs` with the same idempotency key won't result in multiple resources being created.
 
 For example, if a request to initiate a mass payment fails due to a network connection issue, you can reattempt the request with the same idempotency key to ensure that only a single mass payment is created.
 

--- a/pages/api-reference/transfers/initiate.mdx
+++ b/pages/api-reference/transfers/initiate.mdx
@@ -14,7 +14,7 @@ This section covers how to initiate a transfer from either a Dwolla [Account](ht
 
 ### Prevent duplicate transfers with idempotency key
 
-To prevent an operation from being performed more than once, Dwolla supports passing in an `Idempotency-Key` header with a unique key as the value. Multiple `POSTs` with the same idempotency key won't result in multiple resources being created.
+To prevent an operation from being performed more than once, Dwolla supports passing in an <span><ContentTooltip preset="idempotency-key">Idempotency Key</ContentTooltip></span> header with a unique key as the value. Multiple `POSTs` with the same idempotency key won't result in multiple resources being created.
 
 For example, if a request to initiate a transfer fails due to a network connection issue, you can reattempt the request with the same idempotency key to ensure that only a single transfer is created.
 

--- a/pages/docs/balance/auth/index.mdx
+++ b/pages/docs/balance/auth/index.mdx
@@ -20,7 +20,7 @@ Dwolla utilizes the [OAuth 2 protocol](https://oauth.net/2/) to facilitate autho
 
 ## Creating an application
 
-Before you can get started with making OAuth requests, you’ll need to first register an application with Dwolla by logging in and navigating to the applications page in the Dashboard. Once an application is registered you will obtain your `client_id` and `client_secret` (aka client credentials), which will be used to identify your application when calling the Dwolla API. The Sandbox environment provides you with a created application once you have signed up for an account. Learn more in our [Sandbox guide](/guides/sandbox).
+Before you can get started with making OAuth requests, you’ll need to first register an application with Dwolla by logging in and navigating to the applications page in the Dashboard. Once an application is registered you will obtain your `client_id` and `client_secret` (aka client credentials), which will be used to identify your application when calling the Dwolla API. The <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> environment provides you with a created application once you have signed up for an account. Learn more in our [Sandbox guide](/guides/sandbox).
 
 <AlertBar variation="warning">
   Your <code>client_secret</code> should be kept a secret! Be sure to store your

--- a/pages/docs/balance/business-verified-customer/handle-verification-statuses.mdx
+++ b/pages/docs/balance/business-verified-customer/handle-verification-statuses.mdx
@@ -508,7 +508,7 @@ Other business documents may be acceptable on a case by case basis with Dwolla a
 
 To upload a color photo of the document, you’ll initiate a multipart form-data POST request from your backend server to `https://api.dwolla.com/customers/{id}/documents`. The file must be either a .jpg, .jpeg, or .png. Files must be no larger than 10MB in size. Additionally, Business Documents can also be uploaded in a .pdf format.
 
-You’ll also get a webhook with a `customer_verification_document_uploaded` event to let you know the document was successfully uploaded.
+You’ll also get a <span><ContentTooltip preset="webhook" >webhook</ContentTooltip></span> with a `customer_verification_document_uploaded` event to let you know the document was successfully uploaded.
 
 #### Request and response
 

--- a/pages/docs/balance/drop-ins/index.mdx
+++ b/pages/docs/balance/drop-ins/index.mdx
@@ -30,7 +30,7 @@ In this guide, we’ll cover the basics of leveraging Dwolla’s UI Components l
 
 ## Before you begin
 
-If you haven’t already, we encourage you to create a Sandbox account. This will allow you to follow along with the steps outlined in this guide. Check out our [Sandbox guide](/guides/sandbox/) to learn more.
+If you haven’t already, we encourage you to create a <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> account. This will allow you to follow along with the steps outlined in this guide. Check out our [Sandbox guide](/guides/sandbox/) to learn more.
 
 In addition to using the Dwolla Components Library, you’ll need a [server-side SDK](/sdks-tools) in order to facilitate the API request to Dwolla to retrieve a [client-token](https://developers.dwolla.com/api-reference/drop-in-components/create-client-token). A client-token is a unique token scoped to the end user/Customer performing the action on the front-end of your web application.
 

--- a/pages/docs/balance/micro-deposit-verification/initiate-micro-deposits.mdx
+++ b/pages/docs/balance/micro-deposit-verification/initiate-micro-deposits.mdx
@@ -10,7 +10,7 @@ meta:
 
 # Initiate micro-deposits
 
-Once you POST to the [initiate-micro-deposits](https://developers.dwolla.com/api-reference/funding-sources/initiate-micro-deposits) link, Dwolla will send two small amounts to your customer's bank or credit union account. If the request is successful, Dwolla returns a `HTTP 201` and a link to the created micro-deposits resource `funding-sources/{id}/micro-deposits` in the location header. The micro-deposits resource can be later used to retrieve the status of micro-deposits or verify micro-deposit amounts. If your application is subscribed to webhooks, a webhook will be sent with the `microdeposits_added` event, notifying your application that micro-deposits are en route to your customer’s bank account.
+Once you POST to the [initiate-micro-deposits](https://developers.dwolla.com/api-reference/funding-sources/initiate-micro-deposits) link, Dwolla will send two small amounts to your customer's bank or credit union account. If the request is successful, Dwolla returns a `HTTP 201` and a link to the created micro-deposits resource `funding-sources/{id}/micro-deposits` in the location header. The micro-deposits resource can be later used to retrieve the status of micro-deposits or verify micro-deposit amounts. If your application is subscribed to <span><ContentTooltip preset="webhook">webhooks</ContentTooltip></span>, a webhook will be sent with the `microdeposits_added` event, notifying your application that micro-deposits are en route to your customer’s bank account.
 
 ```bash
 POST https://api-sandbox.dwolla.com/funding-sources/e52006c3-7560-4ff1-99d5-b0f3a6f4f909/micro-deposits

--- a/pages/docs/balance/micro-deposit-verification/verify-micro-deposits.mdx
+++ b/pages/docs/balance/micro-deposit-verification/verify-micro-deposits.mdx
@@ -13,8 +13,12 @@ meta:
 In the Dwolla production environment, you must wait until the micro-deposits actually post to the customer’s bank account before the account can be verified, which can take 1-2 business days. A `microdeposits_completed` event will be triggered once micro-deposits have successfully posted to the bank. Once micro-deposits have completed, a `verify-micro-deposits` link relation will return on the funding source letting your application know the funding source can be verified. When the amounts are entered for verification, the order in which they are entered doesn't matter.
 
 <AlertBar variation="info">
-  In the Sandbox environment, any amount below $0.10 will allow you to verify
-  the account immediately.
+  In the{" "}
+  <span>
+    <ContentTooltip preset="sandbox">Sandbox</ContentTooltip>
+  </span>{" "}
+  environment, any amount below $0.10 will allow you to verify the account
+  immediately.
 </AlertBar>
 
 ```bash

--- a/pages/docs/balance/personal-verified-customer/handle-verification-statuses.mdx
+++ b/pages/docs/balance/personal-verified-customer/handle-verification-statuses.mdx
@@ -504,7 +504,7 @@ dwolla.post(kbaUrl, requestBody);
 
 #### KBA Success
 
-If your Customer is able to correctly answer at least three of the four (total) KBA questions, your Customer will be moved into `verified` status. You will receive the `customer_kba_verification_passed` and `customer_verified` webhooks to indicate that your Customer has passed the KBA attempt and has been successfully verified.
+If your Customer is able to correctly answer at least three of the four (total) KBA questions, your Customer will be moved into `verified` status. You will receive the `customer_kba_verification_passed` and `customer_verified` <span><ContentTooltip preset="webhook">webhooks</ContentTooltip></span> to indicate that your Customer has passed the KBA attempt and has been successfully verified.
 
 #### KBA Failure
 

--- a/pages/docs/balance/personal-verified-customer/handle-verification-statuses.mdx
+++ b/pages/docs/balance/personal-verified-customer/handle-verification-statuses.mdx
@@ -28,7 +28,7 @@ It is recommended to have an active [webhook subscription](https://developers.dw
 
 ### Testing verification statuses in Sandbox
 
-Dwolla’s Sandbox environment allows you to submit `verified`, `retry`, `kba`, `document`, or `suspended` as the value of the firstName parameter to create a new verified Customer with their respective status. To simulate transitioning a verified Customer with a `retry` status to `verified`, you’ll need to call the [Update a Customer](https://developers.dwolla.com/api-reference/customers/update) endpoint and submit full identifying information with an updated firstName value and full SSN. To simulate transitioning a verified Customer with a `document` status to `verified` in the Sandbox, you’ll need to upload a test document as outlined in the [Testing in the Sandbox](/guides/sandbox/customers#simulate-document-upload-approved-and-failed-events) resource article.
+Dwolla’s <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> environment allows you to submit `verified`, `retry`, `kba`, `document`, or `suspended` as the value of the firstName parameter to create a new verified Customer with their respective status. To simulate transitioning a verified Customer with a `retry` status to `verified`, you’ll need to call the [Update a Customer](https://developers.dwolla.com/api-reference/customers/update) endpoint and submit full identifying information with an updated firstName value and full SSN. To simulate transitioning a verified Customer with a `document` status to `verified` in the Sandbox, you’ll need to upload a test document as outlined in the [Testing in the Sandbox](/guides/sandbox/customers#simulate-document-upload-approved-and-failed-events) resource article.
 
 ## Handling status: `retry`
 

--- a/pages/docs/balance/receive-money/add-funding-source.mdx
+++ b/pages/docs/balance/receive-money/add-funding-source.mdx
@@ -45,4 +45,4 @@ To integrate Dwolla with Plaid, we recommend checking out our [Add a Bank via Dw
 
 ## Step 2B: Handle Webhooks
 
-If you have an active webhook subscription, you should receive both the `customer_funding_source_added` and `customer_funding_source_verified` webhook immediately following the request to Dwolla to add a funding source using a Plaid `processorToken`.
+If you have an active webhook subscription, you should receive both the `customer_funding_source_added` and `customer_funding_source_verified` <span><ContentTooltip preset="webhook">webhooks</ContentTooltip></span> immediately following the request to Dwolla to add a funding source using a Plaid `processorToken`.

--- a/pages/docs/balance/receive-money/create-a-customer.mdx
+++ b/pages/docs/balance/receive-money/create-a-customer.mdx
@@ -104,7 +104,7 @@ print($customer); # => "https://api-sandbox.dwolla.com/customers/c7f300c0-f1ef-4
   <code>ipAddress</code> parameter. This enhances fraud detection and tracking.
 </AlertBar>
 
-When the Customer is successfully created by your application, you will receive a `201` HTTP response with an empty response body. You can reference the Location header to retrieve a link that represents the created Customer resource. We recommend storing the full URL for future use, as it will be necessary to complete additional actions, such as attaching a bank or correlating webhooks that are triggered for the end user in the Dwolla system.
+When the Customer is successfully created by your application, you will receive a `201` HTTP response with an empty response body. You can reference the Location header to retrieve a link that represents the created Customer resource. We recommend storing the full URL for future use, as it will be necessary to complete additional actions, such as attaching a bank or correlating <span><ContentTooltip preset="webhook">webhooks</ContentTooltip></span> that are triggered for the end user in the Dwolla system.
 
 ## Step 1B. Handle Webhooks
 

--- a/pages/docs/balance/receive-money/create-transfer.mdx
+++ b/pages/docs/balance/receive-money/create-transfer.mdx
@@ -172,7 +172,7 @@ For more information on which webhooks will be fired for a given section of a tr
 
 ## Step 4C: Simulate Payment Processing
 
-To simulate paymentACH processing in the Dwolla Sandbox environment, navigate to the Sandbox Dashboard. From here, you will want to click the “Process Bank Transfers” button on the top of the screen. Your Sandbox transfer will be moved out of a `pending` status and moved to a `processed` status.
+To simulate payment ACH processing in the Dwolla <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> environment, navigate to the Sandbox Dashboard. From here, you will want to click the “Process Bank Transfers” button on the top of the screen. Your Sandbox transfer will be moved out of a `pending` status and moved to a `processed` status.
 
 <Image src={processBankTransfers} alt="process bank transfers" />
 

--- a/pages/docs/balance/receive-money/create-transfer.mdx
+++ b/pages/docs/balance/receive-money/create-transfer.mdx
@@ -163,7 +163,7 @@ dwolla.post("transfers", transferRequest).then(function (res) {
 });
 ```
 
-When the transfer is created, you will receive a `201` HTTP response with an empty response body. You can refer to the Location header to retrieve a link to the created Transfer resource. All bank transactions that are sourced from a bank or that are going to a bank will have an initial status of `pending`. We recommend storing the full Transfer URL for future use, as it will be needed for correlating transfer update webhooks that are triggered for the user in the Dwolla system.
+When the transfer is created, you will receive a `201` HTTP response with an empty response body. You can refer to the Location header to retrieve a link to the created Transfer resource. All bank transactions that are sourced from a bank or that are going to a bank will have an initial status of `pending`. We recommend storing the full Transfer URL for future use, as it will be needed for correlating transfer update <span><ContentTooltip preset="webhook">webhooks</ContentTooltip></span> that are triggered for the user in the Dwolla system.
 
 ## Step 4B: Handle Webhooks
 

--- a/pages/docs/balance/receive-money/index.mdx
+++ b/pages/docs/balance/receive-money/index.mdx
@@ -38,7 +38,7 @@ In this quickstart guide, you’ll learn the following key concepts involved wit
 
 ## Before you begin
 
-We encourage you to create a sandbox account, if you haven’t already. This will allow you to follow along with the steps outlined in this guide. Check out our [Sandbox guide](/guides/sandbox) to learn more on creating an account.
+We encourage you to create a <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> account, if you haven’t already. This will allow you to follow along with the steps outlined in this guide. Check out our [Sandbox guide](/guides/sandbox) to learn more on creating an account.
 
 After creating a sandbox account, you’ll obtain your API Key and Secret, which are used to obtain an OAuth access token. An access token is required in order to authenticate against the Dwolla API. Learn more about how to [obtain an access token](/guides/auth/) in our guide.
 

--- a/pages/docs/balance/send-money/add-funding-source.mdx
+++ b/pages/docs/balance/send-money/add-funding-source.mdx
@@ -125,4 +125,4 @@ When the funding source is created, you will receive a `201` HTTP response with 
 
 ## Step 2B: Handle Webhooks
 
-If you have an active webhook subscription (required in production & optional in Sandbox), you will receive the `customer_funding_source_created` webhook immediately after the resource has been created.
+If you have an active webhook subscription (required in production & optional in Sandbox), you will receive the `customer_funding_source_created` <span><ContentTooltip preset="webhook">webhook</ContentTooltip></span> immediately after the resource has been created.

--- a/pages/docs/balance/send-money/create-a-customer.mdx
+++ b/pages/docs/balance/send-money/create-a-customer.mdx
@@ -109,7 +109,7 @@ print($customer); # => "https://api-sandbox.dwolla.com/customers/c7f300c0-f1ef-4
 ?>
 ```
 
-When the Customer is successfully created on your application, you will receive a `201` HTTP response with an empty response body. You can reference the Location header to retrieve a link that represents the created Customer resource. We recommend storing the full URL for future use, as it will be needed for actions such as attaching a bank or correlating webhooks that are triggered for the user in the Dwolla system.
+When the Customer is successfully created on your application, you will receive a `201` HTTP response with an empty response body. You can reference the Location header to retrieve a link that represents the created Customer resource. We recommend storing the full URL for future use, as it will be needed for actions such as attaching a bank or correlating <span><ContentTooltip preset="webhook">webhooks</ContentTooltip></span> that are triggered for the user in the Dwolla system.
 
 ## Step 1B. Handle Webhooks
 

--- a/pages/docs/balance/send-money/create-transfer.mdx
+++ b/pages/docs/balance/send-money/create-transfer.mdx
@@ -158,7 +158,7 @@ For more information on which webhooks will be fired, refer to our [API Referenc
 
 ## Step 4C: Simulate ACH Processing
 
-To simulate ACH processing in the Dwolla Sandbox environment, navigate to the Sandbox Dashboard. From here, you will want to click the “Process Bank Transfers” button on the top of the screen. Your Sandbox transfer will be moved out of a `pending` status and moved to a `processed` status.
+To simulate ACH processing in the Dwolla <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> environment, navigate to the Sandbox Dashboard. From here, you will want to click the “Process Bank Transfers” button on the top of the screen. Your Sandbox transfer will be moved out of a `pending` status and moved to a `processed` status.
 
 <Image src={processBankTransfers} alt="process bank transfers" />
 

--- a/pages/docs/balance/send-money/create-transfer.mdx
+++ b/pages/docs/balance/send-money/create-transfer.mdx
@@ -149,7 +149,7 @@ print($transfer); # => https://api-sandbox.dwolla.com/transfers/d76265cd-0951-e5
 ?>
 ```
 
-When the transfer is created, you will receive a `201` HTTP response with an empty response body. You can refer to the Location header to retrieve a link to the created Transfer resource. All transactions that are sourced from a bank or that are going to a bank will have an initial status of `pending`. We recommend storing the full Transfer URL for future use, as it will be needed for correlating transfer update webhooks that are triggered for the user in the Dwolla system.
+When the transfer is created, you will receive a `201` HTTP response with an empty response body. You can refer to the Location header to retrieve a link to the created Transfer resource. All transactions that are sourced from a bank or that are going to a bank will have an initial status of `pending`. We recommend storing the full Transfer URL for future use, as it will be needed for correlating transfer update <span><ContentTooltip preset="webhook">webhooks</ContentTooltip></span> that are triggered for the user in the Dwolla system.
 
 ## Step 4B: Handle Webhooks
 

--- a/pages/docs/balance/testing/customers.mdx
+++ b/pages/docs/balance/testing/customers.mdx
@@ -17,7 +17,7 @@ import guidesIcon from "../../../../assets/images/content-images/content-icons/g
 
 ### Manage Customers in the Dashboard
 
-The [Sandbox Dashboard](https://dashboard-sandbox.dwolla.com) allows you to manage Customers, as well as transfers associated with the Customers that belong to your Sandbox account. Once your application has [created its Customers](https://developers.dwolla.com/api-reference/customers/create), you can access the [Sandbox Dashboard](https://dashboard-sandbox.dwolla.com) to validate that the request was recorded properly in our test environment.
+The [Sandbox Dashboard](https://dashboard-sandbox.dwolla.com) allows you to manage Customers, as well as transfers associated with the Customers that belong to your <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> account. Once your application has [created its Customers](https://developers.dwolla.com/api-reference/customers/create), you can access the [Sandbox Dashboard](https://dashboard-sandbox.dwolla.com) to validate that the request was recorded properly in our test environment.
 
 <InlineCTA
   icon={conceptsIcon}

--- a/pages/docs/balance/testing/funding-sources.mdx
+++ b/pages/docs/balance/testing/funding-sources.mdx
@@ -18,7 +18,7 @@ Dwolla requires a valid U.S. routing number and a random account number between 
 
 ### Test micro-deposit verification
 
-If your application leverages the micro-deposit method of bank verification, Dwolla will transfer two deposits of less than `$0.10` to your customer's linked bank or credit union account after calling the API to initiate micro-deposits. Since the Sandbox environment doesn't replicate any bank transfer processes, any two amounts **below** `$0.10` will allow you to verify the funding source immediately. In Production, when the micro-deposits have finished processing, you will receive a `customer_microdeposits_completed` event. To trigger this event in Sandbox, you need to simulate bank transfer processing. Check out the [testing transfers](#testing-transfers) section for more information on how to simulate bank transfer processing in Sandbox.
+If your application leverages the micro-deposit method of bank verification, Dwolla will transfer two deposits of less than `$0.10` to your customer's linked bank or credit union account after calling the API to initiate micro-deposits. Since the <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> environment doesn't replicate any bank transfer processes, any two amounts **below** `$0.10` will allow you to verify the funding source immediately. In Production, when the micro-deposits have finished processing, you will receive a `customer_microdeposits_completed` event. To trigger this event in Sandbox, you need to simulate bank transfer processing. Check out the [testing transfers](#testing-transfers) section for more information on how to simulate bank transfer processing in Sandbox.
 
 <InlineCTA
   icon={guideIcon}

--- a/pages/docs/balance/testing/transfers.mdx
+++ b/pages/docs/balance/testing/transfers.mdx
@@ -13,7 +13,7 @@ import conceptsIcon from "../../../../assets/images/content-images/content-icons
 
 # Testing Transfers
 
-The Sandbox environment does not replicate any bank transfer processes, so a pending transfer will not clear or fail automatically after a few business days as it would in production. The transfer will simply remain in the pending state indefinitely.
+The <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> environment does not replicate any bank transfer processes, so a pending transfer will not clear or fail automatically after a few business days as it would in production. The transfer will simply remain in the pending state indefinitely.
 
 ### Simulate bank transfer processing
 

--- a/pages/docs/balance/transfer-failures.mdx
+++ b/pages/docs/balance/transfer-failures.mdx
@@ -36,7 +36,7 @@ You can check the status of a transfer at any time by [retrieving the transfer v
 
 ### Retrieving the reason for a failed bank transfer
 
-If your application is subscribed to webhooks, you’ll receive either the `transfer_failed` event if the transfer belongs to a Dwolla account or the `customer_transfer_failed`/`customer_bank_transfer_failed`(_Verified Customer only_) event if the transfer belongs to an API Customer. The event contains a links to the associated account as well as the transfer resource. When retrieving the failed bank transfer reason, the response will contain information on the ACH return code and description, as well as `_links` to the Funding Source and Customer that triggered the bank transfer failure.
+If your application is subscribed to <span><ContentTooltip preset="webhook" >webhooks</ContentTooltip></span>, you’ll receive either the `transfer_failed` event if the transfer belongs to a Dwolla account or the `customer_transfer_failed`/`customer_bank_transfer_failed`(_Verified Customer only_) event if the transfer belongs to an API Customer. The event contains a links to the associated account as well as the transfer resource. When retrieving the failed bank transfer reason, the response will contain information on the ACH return code and description, as well as `_links` to the Funding Source and Customer that triggered the bank transfer failure.
 
 ##### Request and response (view schema in 'raw')
 

--- a/pages/docs/balance/transfer-money-me-to-me/add-funding-sources.mdx
+++ b/pages/docs/balance/transfer-money-me-to-me/add-funding-sources.mdx
@@ -41,7 +41,7 @@ To integrate Dwolla with Plaid, we recommend checking out our [Add a Bank via Dw
 
 ## Step 2B: Handle Webhooks
 
-If you have an active webhook subscription, you should receive both the `customer_funding_source_added` and `customer_funding_source_verified` webhook immediately following the request to Dwolla to add a funding source using a Plaid `processorToken`.
+If you have an active webhook subscription, you should receive both the `customer_funding_source_added` and `customer_funding_source_verified` <span><ContentTooltip preset="webhook">webhooks</ContentTooltip></span> immediately following the request to Dwolla to add a funding source using a Plaid `processorToken`.
 
 ## Step 2C: Add a Savings Account
 

--- a/pages/docs/balance/transfer-money-me-to-me/create-a-customer.mdx
+++ b/pages/docs/balance/transfer-money-me-to-me/create-a-customer.mdx
@@ -173,7 +173,7 @@ dwolla
   .then((res) => res.headers.get("location")); // => 'https://api-sandbox.dwolla.com/customers/FC451A7A-AE30-4404-AB95-E3553FCD733F'
 ```
 
-When the Customer is successfully created on your application, you will receive a `201` HTTP response with an empty response body. You can reference the Location header to retrieve a link that represents the created Customer resource. We recommend storing the full URL for future use, as it will be needed for actions such as attaching a bank or correlating webhooks that are triggered for the user in the Dwolla system.
+When the Customer is successfully created on your application, you will receive a `201` HTTP response with an empty response body. You can reference the Location header to retrieve a link that represents the created Customer resource. We recommend storing the full URL for future use, as it will be needed for actions such as attaching a bank or correlating <span><ContentTooltip preset="webhook">webhooks</ContentTooltip></span> that are triggered for the user in the Dwolla system.
 
 <AlertBar variation="info">
   Providing the IP address of the end user accessing your application as the

--- a/pages/docs/balance/transfer-money-me-to-me/create-transfer.mdx
+++ b/pages/docs/balance/transfer-money-me-to-me/create-transfer.mdx
@@ -175,7 +175,7 @@ When the transfer is created, you will receive a `201` HTTP response with an emp
 
 ## Step 4B: Handle Webhooks
 
-If you have an active webhook subscription (required in production & optional in Sandbox), you will receive the `customer_bank_transfer_created` webhook immediately after the transfer resource has been created. This denotes that the first part of the transfer has been initiated from the checking bank funding source to the Balance funding source.
+If you have an active webhook subscription (required in production & optional in <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span>), you will receive the `customer_bank_transfer_created` webhook immediately after the transfer resource has been created. This denotes that the first part of the transfer has been initiated from the checking bank funding source to the Balance funding source.
 
 ## Step 4C: Simulate Bank Transfer Processing
 

--- a/pages/docs/balance/transfer-money-me-to-me/create-transfer.mdx
+++ b/pages/docs/balance/transfer-money-me-to-me/create-transfer.mdx
@@ -175,7 +175,7 @@ When the transfer is created, you will receive a `201` HTTP response with an emp
 
 ## Step 4B: Handle Webhooks
 
-If you have an active webhook subscription (required in production & optional in <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span>), you will receive the `customer_bank_transfer_created` webhook immediately after the transfer resource has been created. This denotes that the first part of the transfer has been initiated from the checking bank funding source to the Balance funding source.
+If you have an active webhook subscription (required in production & optional in <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span>), you will receive the `customer_bank_transfer_created` <span><ContentTooltip preset="webhook">webhook</ContentTooltip></span> immediately after the transfer resource has been created. This denotes that the first part of the transfer has been initiated from the checking bank funding source to the Balance funding source.
 
 ## Step 4C: Simulate Bank Transfer Processing
 

--- a/pages/docs/balance/transfer-money-me-to-me/index.mdx
+++ b/pages/docs/balance/transfer-money-me-to-me/index.mdx
@@ -38,7 +38,7 @@ In this quickstart guide, you’ll learn the key concepts involved with sending 
 
 ## Before you begin
 
-We encourage you to create a sandbox account, if you haven’t already. This will allow you to follow along with the steps outlined in this guide. Check out our [Sandbox guide](/guides/sandbox) to learn more.
+We encourage you to create a <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> account, if you haven’t already. This will allow you to follow along with the steps outlined in this guide. Check out our [Sandbox guide](/guides/sandbox) to learn more.
 
 After creating a sandbox account, you’ll obtain your API Key and Secret, which are used to obtain an OAuth access token. An access token is required in order to authenticate against the Dwolla API. Learn more about how to [obtain an access token in our guide](/guides/auth/).
 

--- a/pages/docs/balance/virtual-account-numbers.mdx
+++ b/pages/docs/balance/virtual-account-numbers.mdx
@@ -176,7 +176,7 @@ Withdrawals from the Dwolla Balance will be represented by a new transfer where 
 }
 ```
 
-Each new transfer will trigger a `bank_transfer_created` or `customer_bank_transfer_created` webhook. The creation webhooks will be triggered approximately 30 minutes prior to any completed webhook event of `bank_transfer_completed` or `customer_bank_transfer_completed`.
+Each new transfer will trigger a `bank_transfer_created` or `customer_bank_transfer_created` <span><ContentTooltip preset="webhook" >webhook</ContentTooltip></span>. The creation webhooks will be triggered approximately 30 minutes prior to any completed webhook event of `bank_transfer_completed` or `customer_bank_transfer_completed`.
 
 Transfers will be created in a `pending` or `failed` status depending on whether the customer record or VAN has been deactivated, suspended, or removed. Pending transfers will be processed automatically during the following times (subject to change).
 

--- a/pages/docs/balance/webhooks/index.mdx
+++ b/pages/docs/balance/webhooks/index.mdx
@@ -71,7 +71,7 @@ Example webhook payload:
 
 ## What to Know About Dwolla Webhooks
 
-- Each application can have multiple webhook subscriptions associated with it. While one subscription is sufficient, you can create up to **five** in Production and **ten** in Sandbox for redundancy.
+- Each application can have multiple webhook subscriptions associated with it. While one subscription is sufficient, you can create up to **five** in Production and **ten** in <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> for redundancy.
 - Webhooks are sent asynchronously and are not guaranteed to be delivered in order. We recommend that applications protect against duplicated events by [making event processing idempotent](/docs/balance/webhooks/process-validate#check-for-duplicate-events).
 - Your application will need to respond to Dwolla webhook requests with a 200-level HTTP status code within 10 seconds of receipt. Otherwise, the attempt will be counted as a failure and Dwolla will retry sending the webhook according to the [back-off schedule](/api-reference/webhook-subscriptions#delivery-rate).
 - If there are 400 consecutive failures, and it has been 24 hours since your last success, your webhook subscription will be automatically paused and an email will be sent to the Admin of the Dwolla account. After fixing the issue that is causing the failures, you can unpause the webhook subscription either via your Dashboard or [Dwolla's API](/api-reference/webhook-subscriptions/update) in order to continue receiving new webhooks and to [retry failed webhooks](/api-reference/webhooks/retry).

--- a/pages/docs/balance/what-is-dwolla-balance.mdx
+++ b/pages/docs/balance/what-is-dwolla-balance.mdx
@@ -23,7 +23,7 @@ The benefits of using Dwolla include:
 
 - Fast and secure payments: Dwolla uses the Automated Clearing House (ACH) network to process payments, which is a secure and reliable way to transfer money.
 - Low fees: Dwolla's transaction fees are lower than those of traditional payment processors; such as credit cards.
-- Flexibility: Dwolla's API is flexible and can be customized to meet the needs of businesses of all sizes. Real-time webhooks enable your application to be in sync with all events that occur on the Dwolla platform.
+- Flexibility: Dwolla's API is flexible and can be customized to meet the needs of businesses of all sizes. Real-time <span><ContentTooltip preset="webhook">webhooks</ContentTooltip></span> enable your application to be in sync with all events that occur on the Dwolla platform.
 - Scalability and reliability: Dwolla is scalable and can handle large volumes of transactions. In addition, the API maintains 99.9% uptime so you can count on reliability as your business grows.
 
 ## Features

--- a/pages/docs/connect/planning-your-integration.mdx
+++ b/pages/docs/connect/planning-your-integration.mdx
@@ -47,11 +47,11 @@ Once you’re done with your bank’s setup process, we’ll provide an agreemen
 
 ### Account Setup
 
-Sign up for your Sandbox account and complete a few forms to help us complete your account setup and our due diligence assessment of your business.
+Sign up for your <span><ContentTooltip preset="sandbox">Sandbox</ContentTooltip></span> account and complete a few forms to help us complete your account setup and our due diligence assessment of your business.
 
 ### Testing
 
-Build and test your integration in our fully simulated sandbox environment.
+Build and test your integration in our fully simulated Sandbox environment.
 
 ### Production
 

--- a/pages/docs/connect/what-is-dwolla-connect.mdx
+++ b/pages/docs/connect/what-is-dwolla-connect.mdx
@@ -50,7 +50,7 @@ Dwolla integrates directly with financial institutions (currently, J.P. Morgan a
 1. Using Dwolla’s API, you initiate a transfer request to push/pull funds between your commercial bank account and an external party’s bank account.
 2. Dwolla receives the transfer request and passes the payment instructions on to the financial institution that holds your commercial account. The financial institution receives the payment instructions and kicks off the process to push (shown above) or pull funds between your commercial bank account and an external party’s bank account.
 3. According to its process, the financial institution debits (shown above) or credits your commercial account for the amount of the transaction and notifies Dwolla.
-4. Dwolla passes automated webhook notifications back to you so you stay updated on the payment’s status.
+4. Dwolla passes automated <span><ContentTooltip preset="webhook">webhook</ContentTooltip></span> notifications back to you so you stay updated on the payment’s status.
 
 <ExternalCTA
   icon={DwollaConnectIcon}

--- a/stories/base/ContentTooltip.stories.tsx
+++ b/stories/base/ContentTooltip.stories.tsx
@@ -1,36 +1,31 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import { AcUnit } from "@mui/icons-material";
 import ContentTooltip from "../../app/components/base/ContentTooltip";
 
 storiesOf("base/ContentTooltip", module)
-  .add("default", () => (
-    <ContentTooltip
-      displayText="a digital wallet"
-      tooltip={{
-        content:
-          "The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds.",
-      }}
-    />
+  .add("default, no icon, no title", () => (
+    <ContentTooltip content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds.">
+      a digital wallet
+    </ContentTooltip>
   ))
-  .add("with icon, without title", () => (
+  .add("with icon, no title", () => (
     <ContentTooltip
-      displayText="testing transfers"
-      tooltip={{
-        content:
-          "The Sandbox environment does not replicate any bank transfer processes, so a pending...",
-        icon: OpenInNewIcon,
-      }}
-    />
+      content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds."
+      icon={AcUnit}
+    >
+      a digital wallet
+    </ContentTooltip>
   ))
   .add("with icon, with title", () => (
     <ContentTooltip
-      displayText="testing transfers"
-      tooltip={{
-        content:
-          "The Sandbox environment does not replicate any bank transfer processes, so a pending...",
-        icon: OpenInNewIcon,
-        title: "Testing Transfers",
-      }}
-    />
+      content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds."
+      icon={AcUnit}
+      title="The Dwolla Balance"
+    >
+      a digital wallet
+    </ContentTooltip>
+  ))
+  .add("with `dwolla-balance` preset", () => (
+    <ContentTooltip preset="dwolla-balance">Dwolla Balance</ContentTooltip>
   ));

--- a/stories/base/ContentTooltip.stories.tsx
+++ b/stories/base/ContentTooltip.stories.tsx
@@ -26,6 +26,24 @@ storiesOf("base/ContentTooltip", module)
       a digital wallet
     </ContentTooltip>
   ))
+  .add("with icon, with title, with href", () => (
+    <ContentTooltip
+      content="The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds."
+      icon={AcUnit}
+      title="The Dwolla Balance"
+      href="https://developers.dwolla.com/docs"
+    >
+      a digital wallet
+    </ContentTooltip>
+  ))
+  .add("with href, no icon", () => (
+    <ContentTooltip
+      content="When a custom icon isn't provided, the tooltip will use a default icon"
+      href="https://developers.dwolla.com/docs"
+    >
+      a digital wallet
+    </ContentTooltip>
+  ))
   .add("with `dwolla-balance` preset", () => (
     <ContentTooltip preset="dwolla-balance">Dwolla Balance</ContentTooltip>
   ));

--- a/stories/base/ContentTooltip.stories.tsx
+++ b/stories/base/ContentTooltip.stories.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import ContentTooltip from "../../app/components/base/ContentTooltip";
+
+storiesOf("base/ContentTooltip", module)
+  .add("default", () => (
+    <ContentTooltip
+      displayText="a digital wallet"
+      tooltip={{
+        content:
+          "The Dwolla balance is a Funding Source that can be utilized like a “wallet” for holding a stored value of USD funds.",
+      }}
+    />
+  ))
+  .add("with icon, without title", () => (
+    <ContentTooltip
+      displayText="testing transfers"
+      tooltip={{
+        content:
+          "The Sandbox environment does not replicate any bank transfer processes, so a pending...",
+        icon: OpenInNewIcon,
+      }}
+    />
+  ))
+  .add("with icon, with title", () => (
+    <ContentTooltip
+      displayText="testing transfers"
+      tooltip={{
+        content:
+          "The Sandbox environment does not replicate any bank transfer processes, so a pending...",
+        icon: OpenInNewIcon,
+        title: "Testing Transfers",
+      }}
+    />
+  ));


### PR DESCRIPTION
FYI, older commits from [DEV-1454](https://github.com/Dwolla/dev-portal/commit/6198422d99b7d96324ac83658cf78ee8aa9cd8cb) also got ported over, which are already in main. Only the following commits need reviewing:

[DEV-1494: Update existing docs to include tooltips where relevant](https://github.com/Dwolla/dev-portal/pull/556/commits/8ea686d9ebab1b391768b8dd5090655303b6d797)

[Add ContenTooltip preset for webhook](https://github.com/Dwolla/dev-portal/pull/556/commits/a10ec318787431e31415786c5c11a3d42017e071)
